### PR TITLE
feat: add ProtectedRoute wrapper for dashboard routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Analytics from './pages/Analytics/Analytics';
 import Settings from './pages/Settings/Settings';
 import HelpCenter from './pages/HelpCenter/HelpCenter';
 import DashboardLayout from './components/layout/DashboardLayout';
+import ProtectedRoute from './components/auth/ProtectedRoute/ProtectedRoute';
 import './App.css';
 
 const router = createBrowserRouter([
@@ -31,35 +32,40 @@ const router = createBrowserRouter([
     element: <ForgotPassword />,
   },
   {
-    element: <DashboardLayout />,
+    element: <ProtectedRoute />,
     children: [
       {
-        path: '/dashboard',
-        element: <Dashboard />,
-      },
-      {
-        path: '/dashboard/shipments',
-        element: <Shipments />,
-      },
-      {
-        path: '/dashboard/blockchain-ledger',
-        element: <BlockchainLedger />,
-      },
-      {
-        path: '/dashboard/settlements',
-        element: <Settlements />,
-      },
-      {
-        path: '/dashboard/analytics',
-        element: <Analytics />,
-      },
-      {
-        path: '/dashboard/settings',
-        element: <Settings />,
-      },
-      {
-        path: '/dashboard/help-center',
-        element: <HelpCenter />,
+        element: <DashboardLayout />,
+        children: [
+          {
+            path: '/dashboard',
+            element: <Dashboard />,
+          },
+          {
+            path: '/dashboard/shipments',
+            element: <Shipments />,
+          },
+          {
+            path: '/dashboard/blockchain-ledger',
+            element: <BlockchainLedger />,
+          },
+          {
+            path: '/dashboard/settlements',
+            element: <Settlements />,
+          },
+          {
+            path: '/dashboard/analytics',
+            element: <Analytics />,
+          },
+          {
+            path: '/dashboard/settings',
+            element: <Settings />,
+          },
+          {
+            path: '/dashboard/help-center',
+            element: <HelpCenter />,
+          },
+        ],
       },
     ],
   },

--- a/frontend/src/components/auth/ProtectedRoute/ProtectedRoute.css
+++ b/frontend/src/components/auth/ProtectedRoute/ProtectedRoute.css
@@ -1,0 +1,25 @@
+.protected-route-loading {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #0f172a;
+  background: #f8fafc;
+  font-weight: 500;
+}
+
+.protected-route-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid #cbd5e1;
+  border-top-color: #0f172a;
+  border-radius: 50%;
+  animation: protected-route-spin 0.8s linear infinite;
+}
+
+@keyframes protected-route-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/components/auth/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute/ProtectedRoute.test.tsx
@@ -1,0 +1,73 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ProtectedRoute from './ProtectedRoute';
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows loading state while checking auth status', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<div>Protected Dashboard</div>} />
+          </Route>
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Checking authentication...')).toBeInTheDocument();
+  });
+
+  it('redirects unauthenticated users to /login', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<div>Protected Dashboard</div>} />
+          </Route>
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+    expect(screen.queryByText('Protected Dashboard')).not.toBeInTheDocument();
+  });
+
+  it('renders protected content for authenticated users', () => {
+    localStorage.setItem('authToken', 'test-token');
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/dashboard" element={<div>Protected Dashboard</div>} />
+          </Route>
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getByText('Protected Dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/components/auth/ProtectedRoute/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from '@hooks/useAuth';
+import './ProtectedRoute.css';
+
+const ProtectedRoute: React.FC = () => {
+  const { isLoading, isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="protected-route-loading" role="status" aria-live="polite">
+        <div className="protected-route-spinner" aria-hidden="true" />
+        <span>Checking authentication...</span>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;
+

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+const AUTH_STORAGE_KEY = 'authToken';
+const AUTH_CHECK_DELAY_MS = 150;
+
+export function useAuth() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const hasAuthToken = Boolean(localStorage.getItem(AUTH_STORAGE_KEY));
+      setIsAuthenticated(hasAuthToken);
+      setIsLoading(false);
+    }, AUTH_CHECK_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return { isLoading, isAuthenticated };
+}
+

--- a/frontend/src/pages/auth/Login/Login.tsx
+++ b/frontend/src/pages/auth/Login/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Eye, EyeOff } from 'lucide-react';
 import '../Signup/Signup.css';
 
@@ -9,6 +9,8 @@ interface FormErrors {
 }
 
 const Login: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -77,8 +79,10 @@ const Login: React.FC = () => {
     setLoading(true);
     // Simulate API call
     setTimeout(() => {
+      localStorage.setItem('authToken', 'navin-demo-token');
+      const from = location.state?.from?.pathname ?? '/dashboard';
       setLoading(false);
-      alert('Login successful (simulation)');
+      navigate(from, { replace: true });
     }, 2000);
   };
 


### PR DESCRIPTION
## Summary
- add a `ProtectedRoute` wrapper that checks auth status before rendering dashboard routes
- redirect unauthenticated users to `/login` and show a brief loading state during auth check
- update simulated login flow to persist `authToken` and navigate users back to their originally requested route

## Test plan
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run test`
- [x] `cd frontend && npm run build`

Closes #21
