### PR TITLE
feat: build recent shipments table for company dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import Home from './pages/Home/Home';
 import Signup from './pages/auth/Signup/Signup';
 import Login from './pages/auth/Login/Login';
 import ForgotPassword from './pages/auth/ForgotPassword/ForgotPassword';
-import Dashboard from './pages/dashboard/Dashboard';
+import CompanyDashboard from './pages/dashboard/Company/CompanyDashboard';
 import Shipments from './pages/Shipments/Shipments';
 import BlockchainLedger from './pages/BlockchainLedger/BlockchainLedger';
 import Settlements from './pages/Settlements/Settlements';
@@ -39,7 +39,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: '/dashboard',
-            element: <Dashboard />,
+            element: <CompanyDashboard />,
           },
           {
             path: '/dashboard/shipments',

--- a/frontend/src/pages/dashboard/Company/CompanyDashboard.tsx
+++ b/frontend/src/pages/dashboard/Company/CompanyDashboard.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import {
+  LayoutGrid,
+  ChevronDown,
+  Box,
+  ShieldCheck,
+  Banknote,
+  Plus,
+  Cpu,
+  Clock,
+  ArrowUpRight,
+  ArrowDownRight,
+} from 'lucide-react';
+import RecentShipments from './RecentShipments/RecentShipments';
+import '../../dashboard/Dashboard.css';
+
+const CompanyDashboard: React.FC = () => {
+  const stats = [
+    {
+      label: 'Total Shipments',
+      value: '1,248',
+      trend: '+4.2%',
+      trendType: 'up',
+      icon: <Box size={20} />,
+    },
+    {
+      label: 'In Transit',
+      value: '342',
+      trend: 'Active',
+      trendType: 'neutral',
+      icon: <Cpu size={20} />,
+    },
+    {
+      label: 'Delivered',
+      value: '856',
+      trend: '98% Goal',
+      trendType: 'up',
+      icon: <ShieldCheck size={20} />,
+    },
+    {
+      label: 'Pending Payment',
+      value: '$42.5k',
+      trend: '-1.2%',
+      trendType: 'down',
+      icon: <Banknote size={20} />,
+    },
+  ] as const;
+
+  return (
+    <div className="dashboard-home">
+      <div className="dashboard-header">
+        <div className="header-title">
+          <h1>Logistics Overview</h1>
+          <p>Real-time status of your global supply chain on the blockchain.</p>
+        </div>
+        <div className="date-selector">
+          <Clock size={16} />
+          <span>Last 30 Days</span>
+          <ChevronDown size={14} />
+        </div>
+      </div>
+
+      <div className="dashboard-left-col">
+        <div className="stats-grid">
+          {stats.map(stat => (
+            <div key={stat.label} className="stat-card">
+              <div className="stat-header">
+                <div className="stat-icon">{stat.icon}</div>
+                <div className={`stat-trend trend-${stat.trendType}`}>
+                  {stat.trendType === 'up' && <ArrowUpRight size={14} />}
+                  {stat.trendType === 'down' && <ArrowDownRight size={14} />}
+                  {stat.trend}
+                </div>
+              </div>
+              <div className="stat-label">{stat.label}</div>
+              <div className="stat-value">{stat.value}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="content-section">
+          <div className="section-title">
+            <h2>
+              <LayoutGrid size={18} />
+              Recent Shipments
+            </h2>
+            <span className="view-all">View All</span>
+          </div>
+          <RecentShipments />
+        </div>
+      </div>
+
+      <div className="right-rail">
+        <div className="rail-card">
+          <h3>Quick Actions</h3>
+          <div className="quick-actions-list">
+            <button className="action-button primary" type="button">
+              <span className="action-label">Create New Shipment</span>
+              <div className="action-icon">
+                <Plus size={20} />
+              </div>
+            </button>
+            <button className="action-button" type="button">
+              <span className="action-label">Track Token Asset</span>
+              <div className="action-icon">
+                <LayoutGrid size={20} />
+              </div>
+            </button>
+            <button className="action-button" type="button">
+              <span className="action-label">Generate Settlement</span>
+              <div className="action-icon">
+                <Banknote size={20} />
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <div className="rail-card">
+          <div className="distribution-header">
+            <h3>Network Distribution</h3>
+          </div>
+          <div className="map-placeholder">
+            <svg width="100%" height="100%" viewBox="0 0 100 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M10 30 Q 25 10, 40 30 T 70 30 T 90 20"
+                stroke="#1e2433"
+                strokeWidth="0.5"
+                fill="none"
+              />
+              <circle cx="20" cy="25" r="1.5" fill="#3b82f6" />
+              <circle cx="45" cy="35" r="1.5" fill="#10b981" />
+              <circle cx="75" cy="20" r="1.5" fill="#3b82f6" />
+              <circle cx="85" cy="40" r="1.5" fill="#3b82f6" />
+            </svg>
+          </div>
+          <div className="distribution-stats">
+            <div className="dist-stat-item">
+              <span className="dist-stat-label">Active Nodes</span>
+              <span className="dist-stat-value">142</span>
+            </div>
+            <div className="dist-stat-item">
+              <span className="dist-stat-label">TPS</span>
+              <span className="dist-stat-value">2,140</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompanyDashboard;
+

--- a/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.css
+++ b/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.css
@@ -1,0 +1,148 @@
+.recent-shipments-table .sortable-header {
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: inherit;
+  text-transform: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.recent-shipments-table .sortable-header:hover {
+  color: var(--text-primary);
+}
+
+.status-pending-approval {
+  background-color: rgba(245, 158, 11, 0.1);
+  color: #fbbf24;
+}
+
+.status-cancelled {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: #f87171;
+}
+
+.recent-shipments-skeleton {
+  padding: 16px 24px 24px;
+}
+
+.recent-shipments-skeleton-row {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(90px, 1fr));
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.recent-shipments-skeleton-row:last-child {
+  border-bottom: none;
+}
+
+.skeleton-cell {
+  height: 14px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #1f2937 25%, #374151 50%, #1f2937 75%);
+  background-size: 250% 100%;
+  animation: shipment-skeleton-shimmer 1.4s infinite;
+}
+
+@keyframes shipment-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.recent-shipments-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+}
+
+.recent-shipments-empty h3 {
+  font-size: 18px;
+}
+
+.recent-shipments-empty p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  max-width: 420px;
+}
+
+.create-shipment-button {
+  margin-top: 8px;
+  background-color: var(--accent-blue);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.table-pagination {
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 24px;
+  gap: 12px;
+}
+
+.pagination-nav,
+.pagination-page {
+  border: 1px solid var(--border-color);
+  background: #121620;
+  color: #d1d5db;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.pagination-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+}
+
+.pagination-pages {
+  display: flex;
+  gap: 8px;
+}
+
+.pagination-page {
+  min-width: 32px;
+  padding: 6px 10px;
+}
+
+.pagination-page.is-active {
+  background: var(--accent-blue);
+  border-color: var(--accent-blue);
+  color: white;
+}
+
+.pagination-nav:disabled,
+.pagination-page:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .table-pagination {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+

--- a/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.test.tsx
+++ b/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.test.tsx
@@ -1,0 +1,88 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RecentShipments from './RecentShipments';
+
+const getFirstDataRow = () => {
+  const rows = screen.getAllByRole('row');
+  return rows[1];
+};
+
+describe('RecentShipments', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows a loading skeleton before data is loaded', () => {
+    render(<RecentShipments />);
+
+    expect(screen.getByLabelText('Recent shipments loading')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('Shipment ID')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no shipments', () => {
+    render(<RecentShipments shipments={[]} loadingDelayMs={0} />);
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(screen.getByText('No shipments found')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create your first shipment/i })).toBeInTheDocument();
+  });
+
+  it('sorts by created date when header is clicked', () => {
+    render(<RecentShipments loadingDelayMs={0} />);
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(within(getFirstDataRow()).getByText('SHP-1001')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by created date/i }));
+
+    expect(within(getFirstDataRow()).getByText('SHP-1015')).toBeInTheDocument();
+  });
+
+  it('sorts by status and toggles direction', () => {
+    render(<RecentShipments loadingDelayMs={0} />);
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by status/i }));
+    expect(within(getFirstDataRow()).getByText('Pending Approval')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /sort by status/i }));
+    expect(within(getFirstDataRow()).getByText('Cancelled')).toBeInTheDocument();
+  });
+
+  it('paginates with next and page number controls', () => {
+    render(<RecentShipments loadingDelayMs={0} />);
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(screen.getByRole('button', { name: 'Page 1' })).toHaveAttribute('aria-current', 'page');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Page 2' }));
+    expect(screen.getByRole('button', { name: 'Page 2' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByText('SHP-1006')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(screen.getByRole('button', { name: 'Page 3' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByText('SHP-1011')).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.tsx
+++ b/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.tsx
@@ -1,0 +1,215 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, ChevronsUpDown } from 'lucide-react';
+import { MOCK_SHIPMENTS, type Shipment } from './mockShipments';
+import './RecentShipments.css';
+
+type SortKey = 'createdAt' | 'status';
+type SortDirection = 'asc' | 'desc';
+
+interface RecentShipmentsProps {
+  shipments?: Shipment[];
+  loadingDelayMs?: number;
+}
+
+const PAGE_SIZE = 5;
+
+const statusRank: Record<Shipment['status'], number> = {
+  'Pending Approval': 1,
+  'In Transit': 2,
+  Delivered: 3,
+  Cancelled: 4,
+};
+
+const formatCreatedDate = (createdAt: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(createdAt));
+
+const statusClassName = (status: Shipment['status']) =>
+  `status-${status.toLowerCase().replace(/\s+/g, '-')}`;
+
+const RecentShipments: React.FC<RecentShipmentsProps> = ({
+  shipments = MOCK_SHIPMENTS,
+  loadingDelayMs = 500,
+}) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadedShipments, setLoadedShipments] = useState<Shipment[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortKey, setSortKey] = useState<SortKey>('createdAt');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setLoadedShipments(shipments);
+      setIsLoading(false);
+    }, loadingDelayMs);
+
+    return () => window.clearTimeout(timer);
+  }, [shipments, loadingDelayMs]);
+
+  const sortedShipments = useMemo(() => {
+    const sorted = [...loadedShipments].sort((a, b) => {
+      if (sortKey === 'createdAt') {
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      }
+
+      return statusRank[a.status] - statusRank[b.status];
+    });
+
+    return sortDirection === 'asc' ? sorted : sorted.reverse();
+  }, [loadedShipments, sortKey, sortDirection]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedShipments.length / PAGE_SIZE));
+  const activePage = Math.min(currentPage, totalPages);
+
+  const currentRows = useMemo(() => {
+    const start = (activePage - 1) * PAGE_SIZE;
+    return sortedShipments.slice(start, start + PAGE_SIZE);
+  }, [activePage, sortedShipments]);
+
+  const handleSort = (nextKey: SortKey) => {
+    if (sortKey === nextKey) {
+      setCurrentPage(1);
+      setSortDirection(prev => (prev === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+
+    setCurrentPage(1);
+    setSortKey(nextKey);
+    setSortDirection('asc');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="recent-shipments-skeleton" aria-label="Recent shipments loading">
+        {Array.from({ length: PAGE_SIZE }).map((_, idx) => (
+          <div className="recent-shipments-skeleton-row" key={idx}>
+            <span className="skeleton-cell" />
+            <span className="skeleton-cell" />
+            <span className="skeleton-cell" />
+            <span className="skeleton-cell" />
+            <span className="skeleton-cell" />
+            <span className="skeleton-cell" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (sortedShipments.length === 0) {
+    return (
+      <div className="recent-shipments-empty">
+        <h3>No shipments found</h3>
+        <p>Start by creating your first shipment to track your delivery pipeline.</p>
+        <button type="button" className="create-shipment-button">
+          Create your first shipment
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <table className="shipments-table recent-shipments-table">
+        <thead>
+          <tr>
+            <th>Shipment ID</th>
+            <th>Origin</th>
+            <th>Destination</th>
+            <th>
+              <button
+                type="button"
+                className="sortable-header"
+                onClick={() => handleSort('status')}
+                aria-label={`Sort by status (${sortDirection})`}
+              >
+                Status
+                <ChevronsUpDown size={14} />
+              </button>
+            </th>
+            <th>
+              <button
+                type="button"
+                className="sortable-header"
+                onClick={() => handleSort('createdAt')}
+                aria-label={`Sort by created date (${sortDirection})`}
+              >
+                Created Date
+                <ChevronsUpDown size={14} />
+              </button>
+            </th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {currentRows.map(shipment => (
+            <tr key={shipment.id}>
+              <td className="shipment-id-cell">{shipment.id}</td>
+              <td>{shipment.origin}</td>
+              <td>{shipment.destination}</td>
+              <td>
+                <span className={`status-badge ${statusClassName(shipment.status)}`}>
+                  {shipment.status}
+                </span>
+              </td>
+              <td>{formatCreatedDate(shipment.createdAt)}</td>
+              <td>
+                <button type="button" className="verify-button">
+                  View
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="table-pagination" aria-label="Recent shipments pagination">
+        <button
+          type="button"
+          className="pagination-nav"
+          onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+          disabled={activePage === 1}
+          aria-label="Previous page"
+        >
+          <ChevronLeft size={14} />
+          Prev
+        </button>
+
+        <div className="pagination-pages">
+          {Array.from({ length: totalPages }).map((_, idx) => {
+            const page = idx + 1;
+
+            return (
+              <button
+                type="button"
+                key={page}
+                className={`pagination-page ${page === activePage ? 'is-active' : ''}`}
+                onClick={() => setCurrentPage(page)}
+                aria-label={`Page ${page}`}
+                aria-current={page === activePage ? 'page' : undefined}
+              >
+                {page}
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          className="pagination-nav"
+          onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
+          disabled={activePage === totalPages}
+          aria-label="Next page"
+        >
+          Next
+          <ChevronRight size={14} />
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default RecentShipments;
+

--- a/frontend/src/pages/dashboard/Company/RecentShipments/mockShipments.ts
+++ b/frontend/src/pages/dashboard/Company/RecentShipments/mockShipments.ts
@@ -1,0 +1,32 @@
+export type ShipmentStatus =
+  | 'In Transit'
+  | 'Delivered'
+  | 'Pending Approval'
+  | 'Cancelled';
+
+export interface Shipment {
+  id: string;
+  origin: string;
+  destination: string;
+  status: ShipmentStatus;
+  createdAt: string;
+}
+
+export const MOCK_SHIPMENTS: Shipment[] = [
+  { id: 'SHP-1001', origin: 'Singapore', destination: 'Rotterdam', status: 'In Transit', createdAt: '2026-02-19T09:20:00Z' },
+  { id: 'SHP-1002', origin: 'Mumbai', destination: 'Dubai', status: 'Delivered', createdAt: '2026-02-18T07:10:00Z' },
+  { id: 'SHP-1003', origin: 'Hamburg', destination: 'Chicago', status: 'Pending Approval', createdAt: '2026-02-17T12:45:00Z' },
+  { id: 'SHP-1004', origin: 'Busan', destination: 'Long Beach', status: 'In Transit', createdAt: '2026-02-16T16:30:00Z' },
+  { id: 'SHP-1005', origin: 'Antwerp', destination: 'Lagos', status: 'Cancelled', createdAt: '2026-02-15T10:05:00Z' },
+  { id: 'SHP-1006', origin: 'Jakarta', destination: 'Melbourne', status: 'Delivered', createdAt: '2026-02-14T14:50:00Z' },
+  { id: 'SHP-1007', origin: 'Los Angeles', destination: 'Tokyo', status: 'In Transit', createdAt: '2026-02-13T06:40:00Z' },
+  { id: 'SHP-1008', origin: 'Shenzhen', destination: 'San Francisco', status: 'Pending Approval', createdAt: '2026-02-12T08:35:00Z' },
+  { id: 'SHP-1009', origin: 'Durban', destination: 'Santos', status: 'Delivered', createdAt: '2026-02-11T11:25:00Z' },
+  { id: 'SHP-1010', origin: 'Valencia', destination: 'Algiers', status: 'In Transit', createdAt: '2026-02-10T05:15:00Z' },
+  { id: 'SHP-1011', origin: 'Manila', destination: 'Seattle', status: 'Cancelled', createdAt: '2026-02-09T13:00:00Z' },
+  { id: 'SHP-1012', origin: 'Jebel Ali', destination: 'Mumbai', status: 'Delivered', createdAt: '2026-02-08T19:30:00Z' },
+  { id: 'SHP-1013', origin: 'Ho Chi Minh City', destination: 'Osaka', status: 'In Transit', createdAt: '2026-02-07T09:55:00Z' },
+  { id: 'SHP-1014', origin: 'Colombo', destination: 'Hamburg', status: 'Pending Approval', createdAt: '2026-02-06T04:45:00Z' },
+  { id: 'SHP-1015', origin: 'Alexandria', destination: 'Piraeus', status: 'Delivered', createdAt: '2026-02-05T17:20:00Z' },
+];
+


### PR DESCRIPTION
## Summary
- add `RecentShipments` table component for company dashboard with 6 required columns (Shipment ID, Origin, Destination, Status, Created Date, Actions)
- implement sortable headers for `Status` and `Created Date` with asc/desc toggling, page-number pagination with prev/next, loading skeleton, and empty state CTA
- integrate new `CompanyDashboard` into `/dashboard` route and add deterministic tests for loading, empty, sorting, and pagination behavior

## Test plan
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm run test`
- [x] Attach dashboard screenshot to this PR (required by issue checklist)

## Notes
- this PR is intentionally clean and includes only issue-25 commit `7c0b362`

Closes #25