### PR TITLE
feat: build shipment status update component

### DIFF
--- a/frontend/src/components/shipment/StatusUpdate/StatusUpdate.css
+++ b/frontend/src/components/shipment/StatusUpdate/StatusUpdate.css
@@ -1,0 +1,134 @@
+.status-update {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.status-update-trigger {
+  border: 1px solid var(--border-color, #1e2433);
+  background: #121620;
+  color: var(--text-primary, #ffffff);
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  min-width: 180px;
+  text-align: left;
+}
+
+.status-update-trigger:hover {
+  border-color: var(--accent-blue, #3b82f6);
+}
+
+.status-update-menu {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  border: 1px solid var(--border-color, #1e2433);
+  border-radius: 10px;
+  background: var(--bg-card, #0f121a);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 220px;
+  z-index: 30;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.25);
+}
+
+.status-update-option {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text-primary, #ffffff);
+  text-align: left;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.status-update-option:hover {
+  background: #1a2030;
+}
+
+.status-update-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.status-update-dialog {
+  width: min(92vw, 420px);
+  border: 1px solid var(--border-color, #1e2433);
+  border-radius: 14px;
+  padding: 18px;
+  background: var(--bg-card, #0f121a);
+  color: var(--text-primary, #ffffff);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.35);
+}
+
+.status-update-dialog h3 {
+  margin: 0 0 8px;
+  font-size: 17px;
+}
+
+.status-update-dialog p {
+  margin: 0;
+  color: var(--text-secondary, #9ca3af);
+  font-size: 14px;
+}
+
+.status-update-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.status-update-cancel,
+.status-update-confirm {
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #1e2433);
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.status-update-cancel {
+  background: transparent;
+  color: var(--text-primary, #ffffff);
+}
+
+.status-update-confirm {
+  background: var(--accent-blue, #3b82f6);
+  border-color: var(--accent-blue, #3b82f6);
+  color: #ffffff;
+}
+
+.status-update-cancel:disabled,
+.status-update-confirm:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.status-update-feedback {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-update-feedback.success {
+  color: #10b981;
+}
+
+.status-update-feedback.error {
+  color: #f87171;
+}

--- a/frontend/src/components/shipment/StatusUpdate/StatusUpdate.test.tsx
+++ b/frontend/src/components/shipment/StatusUpdate/StatusUpdate.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import StatusUpdate from './StatusUpdate';
+
+describe('StatusUpdate', () => {
+  it('shows a dropdown with five milestone options', () => {
+    render(<StatusUpdate shipmentId="1234" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update status for shipment 1234/i }));
+
+    expect(screen.getByRole('listbox', { name: /shipment milestones/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Picked Up' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'In Transit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'At Checkpoint' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Out for Delivery' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delivered' })).toBeInTheDocument();
+  });
+
+  it('opens confirmation dialog and closes on cancel', () => {
+    const onStatusUpdate = vi.fn().mockResolvedValue(undefined);
+
+    render(<StatusUpdate shipmentId="1234" onStatusUpdate={onStatusUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update status for shipment 1234/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'In Transit' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Update shipment #1234 to In Transit?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onStatusUpdate).not.toHaveBeenCalled();
+  });
+
+  it('confirms status update and shows success feedback', async () => {
+    const onStatusUpdate = vi.fn().mockResolvedValue(undefined);
+
+    render(<StatusUpdate shipmentId="1234" onStatusUpdate={onStatusUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update status for shipment 1234/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delivered' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(onStatusUpdate).toHaveBeenCalledWith('1234', 'Delivered');
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Shipment #1234 updated to Delivered.');
+  });
+
+  it('shows error feedback when update fails', async () => {
+    const onStatusUpdate = vi.fn().mockRejectedValue(new Error('Could not update shipment'));
+
+    render(<StatusUpdate shipmentId="1234" onStatusUpdate={onStatusUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /update status for shipment 1234/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Out for Delivery' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not update shipment');
+    });
+  });
+});

--- a/frontend/src/components/shipment/StatusUpdate/StatusUpdate.tsx
+++ b/frontend/src/components/shipment/StatusUpdate/StatusUpdate.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import './StatusUpdate.css';
+
+export type ShipmentMilestone =
+  | 'Picked Up'
+  | 'In Transit'
+  | 'At Checkpoint'
+  | 'Out for Delivery'
+  | 'Delivered';
+
+export interface StatusUpdateProps {
+  shipmentId: string;
+  currentStatus?: ShipmentMilestone;
+  onStatusUpdate?: (shipmentId: string, nextStatus: ShipmentMilestone) => Promise<void>;
+}
+
+const MILESTONE_OPTIONS: ShipmentMilestone[] = [
+  'Picked Up',
+  'In Transit',
+  'At Checkpoint',
+  'Out for Delivery',
+  'Delivered',
+];
+
+const StatusUpdate: React.FC<StatusUpdateProps> = ({
+  shipmentId,
+  currentStatus,
+  onStatusUpdate,
+}) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [pendingStatus, setPendingStatus] = useState<ShipmentMilestone | null>(null);
+  const [activeStatus, setActiveStatus] = useState<ShipmentMilestone | undefined>(currentStatus);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    setActiveStatus(currentStatus);
+  }, [currentStatus]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (!successMessage) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setSuccessMessage('');
+    }, 3000);
+
+    return () => window.clearTimeout(timer);
+  }, [successMessage]);
+
+  const dialogMessage = useMemo(() => {
+    if (!pendingStatus) {
+      return '';
+    }
+
+    return `Update shipment #${shipmentId} to ${pendingStatus}?`;
+  }, [pendingStatus, shipmentId]);
+
+  const openConfirmation = (status: ShipmentMilestone) => {
+    setErrorMessage('');
+    setIsMenuOpen(false);
+    setPendingStatus(status);
+    setIsDialogOpen(true);
+  };
+
+  const handleCancel = () => {
+    setIsDialogOpen(false);
+    setPendingStatus(null);
+    triggerRef.current?.focus();
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingStatus) {
+      return;
+    }
+
+    setIsUpdating(true);
+    setErrorMessage('');
+
+    try {
+      if (onStatusUpdate) {
+        await onStatusUpdate(shipmentId, pendingStatus);
+      }
+
+      setActiveStatus(pendingStatus);
+      setSuccessMessage(`Shipment #${shipmentId} updated to ${pendingStatus}.`);
+      setIsDialogOpen(false);
+      setPendingStatus(null);
+      triggerRef.current?.focus();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update shipment status.';
+      setErrorMessage(message);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <div className="status-update" ref={containerRef}>
+      <button
+        type="button"
+        className="status-update-trigger"
+        onClick={() => setIsMenuOpen(prev => !prev)}
+        aria-expanded={isMenuOpen}
+        aria-haspopup="listbox"
+        aria-label={`Update status for shipment ${shipmentId}`}
+        ref={triggerRef}
+      >
+        {activeStatus ? `Status: ${activeStatus}` : 'Update Status'}
+      </button>
+
+      {isMenuOpen && (
+        <ul className="status-update-menu" role="listbox" aria-label="Shipment milestones">
+          {MILESTONE_OPTIONS.map(status => (
+            <li key={status}>
+              <button
+                type="button"
+                className="status-update-option"
+                onClick={() => openConfirmation(status)}
+              >
+                {status}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {isDialogOpen && pendingStatus && (
+        <div className="status-update-dialog-backdrop">
+          <div
+            className="status-update-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`status-update-title-${shipmentId}`}
+            aria-describedby={`status-update-message-${shipmentId}`}
+          >
+            <h3 id={`status-update-title-${shipmentId}`}>Confirm status update</h3>
+            <p id={`status-update-message-${shipmentId}`}>{dialogMessage}</p>
+
+            <div className="status-update-actions">
+              <button type="button" className="status-update-cancel" onClick={handleCancel} disabled={isUpdating}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="status-update-confirm"
+                onClick={handleConfirm}
+                disabled={isUpdating}
+              >
+                {isUpdating ? 'Updating...' : 'Confirm'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {successMessage && (
+        <p className="status-update-feedback success" role="status" aria-live="polite">
+          {successMessage}
+        </p>
+      )}
+      {errorMessage && (
+        <p className="status-update-feedback error" role="alert">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default StatusUpdate;


### PR DESCRIPTION
## Summary
- Add reusable `StatusUpdate` component for shipment milestone progression with 5 dropdown options
- Add confirmation dialog flow (Cancel/Confirm) using shipment ID + selected status prompt
- Add success/error feedback states and unit tests for dropdown, dialog, success, and error paths

Closes #27

## Test plan
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npm run test`
- [ ] Attach UI screenshot for dropdown -> dialog -> success flow

Made with [Cursor](https://cursor.com)