### PR TITLE
feat(landing): add CTA banner component and styles

### DIFF
--- a/frontend/src/LandingPage/LandingPage.tsx
+++ b/frontend/src/LandingPage/LandingPage.tsx
@@ -3,6 +3,7 @@ import Hero from "./sections/Hero/Hero";
 import HowItWorks from "@/LandingPage/sections/HowItWorks/HowItWorks";
 import WhyNavin from "@/LandingPage/sections/WhyNavin/WhyNavin";
 import Features from "@/pages/LandingPage/sections/Features/Features";
+import CTABanner from "@/pages/LandingPage/sections/CTABanner/CTABanner";
 
 const LandingPage: React.FC = () => {
     return (
@@ -11,6 +12,7 @@ const LandingPage: React.FC = () => {
             <WhyNavin />
             <Features />
             <HowItWorks />
+            <CTABanner />
         </main>
     );
 };

--- a/frontend/src/pages/LandingPage/sections/CTABanner/CTABanner.css
+++ b/frontend/src/pages/LandingPage/sections/CTABanner/CTABanner.css
@@ -1,0 +1,49 @@
+/* Full width banner with gradient background */
+.cta-banner {
+    width: 100%;
+    padding: 4rem 1rem;
+    background: linear-gradient(135deg, #005f73 0%, #0a9396 100%);
+    color: white;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+}
+
+.cta-banner__content {
+    max-width: 800px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.cta-banner__headline {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.cta-banner__subheadline {
+    font-size: 1.125rem;
+    margin: 0;
+    line-height: 1.5;
+    max-width: 600px;
+}
+
+/* adjust sizes on larger screens */
+@media (min-width: 640px) {
+    .cta-banner__headline {
+        font-size: 2.5rem;
+    }
+    .cta-banner__subheadline {
+        font-size: 1.25rem;
+    }
+}
+
+.cta-banner__button {
+    transition: transform 0.2s ease;
+}
+
+.cta-banner__button:hover {
+    transform: translateY(-2px);
+}

--- a/frontend/src/pages/LandingPage/sections/CTABanner/CTABanner.test.tsx
+++ b/frontend/src/pages/LandingPage/sections/CTABanner/CTABanner.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import CTABanner from "./CTABanner";
+
+describe("CTABanner", () => {
+    it("renders headline, subheadline, and button", () => {
+        render(<CTABanner />);
+        expect(
+            screen.getByText(/Ready to Transform Your Logistics\?/i)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/Start Tracking Today/i)
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/LandingPage/sections/CTABanner/CTABanner.tsx
+++ b/frontend/src/pages/LandingPage/sections/CTABanner/CTABanner.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import Button from "@/components/Button/Button";
+import "./CTABanner.css";
+
+const CTABanner: React.FC = () => {
+    return (
+        <section className="cta-banner">
+            <div className="cta-banner__content">
+                <h2 className="cta-banner__headline">
+                    Ready to Transform Your Logistics?
+                </h2>
+                <p className="cta-banner__subheadline">
+                    Join thousands of businesses speeding up shipments with Navin. 
+                    Get started today and gain full visibility into your supply chain.
+                </p>
+                <Button variant="primary" size="lg" className="cta-banner__button">
+                    Start Tracking Today
+                </Button>
+            </div>
+        </section>
+    );
+};
+
+export default CTABanner;


### PR DESCRIPTION
Closes #15 

Feature: Add a full‑width call‑to‑action banner to the landing page
Goal: “Ready to Transform Your Logistics?” banner with gradient background, centered copy, and a prominent CTA button.

Use the Figma design (link provided separately) for visual guidance.
– Banner sits at the bottom of the landing page
– Brand‑colored gradient background
– Headline, sub‑headline and a “Start Tracking Today” button
– Responsive, centered text
– Hover state on the button

## Checklist 
- [x]    The Banner component created in correct directory
- [x]     No external images/assets were needed
- [x]     PR description explains the approach (this text)
- [x]     cd frontend && pnpm run build – builds successfully
- [x]     cd frontend && pnpm run test – all tests pass

