### PR TITLE
feat: add NotificationPreferences settings section

### DIFF
--- a/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.css
+++ b/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.css
@@ -1,0 +1,204 @@
+.notif-pref-container {
+  background-color: #14171E;
+  border: 1px solid #1E293B;
+  border-radius: 12px;
+  overflow: hidden;
+  max-width: 640px;
+}
+
+.notif-pref-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 24px;
+  border-bottom: 1px solid #1E293B;
+}
+
+.notif-pref-icon {
+  color: #3B82F6;
+  background: rgba(59, 130, 246, 0.1);
+  padding: 6px;
+  border-radius: 8px;
+  box-sizing: content-box;
+  flex-shrink: 0;
+}
+
+.notif-pref-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #F1F5F9;
+  margin: 0 0 4px 0;
+}
+
+.notif-pref-header p {
+  font-size: 13px;
+  color: #64748B;
+  margin: 0;
+}
+
+.notif-pref-list {
+  padding: 8px 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-pref-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(30, 41, 59, 0.5);
+}
+
+.notif-pref-row:last-child {
+  border-bottom: none;
+}
+
+.notif-pref-info {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.notif-pref-label {
+  font-size: 15px;
+  font-weight: 500;
+  color: #E2E8F0;
+}
+
+.notif-pref-desc {
+  font-size: 13px;
+  color: #64748B;
+}
+
+/* Toggle switch */
+.notif-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.notif-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.notif-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: #1E293B;
+  border: 1px solid #334155;
+  transition: 0.3s;
+}
+
+.notif-slider:before {
+  position: absolute;
+  content: '';
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #94A3B8;
+  transition: 0.3s;
+}
+
+.notif-switch input:checked + .notif-slider {
+  background-color: rgba(59, 130, 246, 0.1);
+  border-color: #3B82F6;
+}
+
+.notif-switch input:checked + .notif-slider:before {
+  background-color: #3B82F6;
+  transform: translateX(20px);
+}
+
+.notif-slider.round {
+  border-radius: 24px;
+}
+
+.notif-slider.round:before {
+  border-radius: 50%;
+}
+
+/* Footer */
+.notif-pref-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
+  border-top: 1px solid #1E293B;
+}
+
+.notif-success-toast {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #10B981;
+  background-color: rgba(16, 185, 129, 0.1);
+  padding: 8px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  animation: notifSlideIn 0.3s ease-out;
+}
+
+.notif-save-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background-color: #3B82F6;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.notif-save-btn:hover:not(:disabled) {
+  background-color: #2563EB;
+}
+
+.notif-save-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.notif-spinner {
+  animation: notifSpin 1s linear infinite;
+}
+
+@keyframes notifSpin {
+  100% { transform: rotate(360deg); }
+}
+
+@keyframes notifSlideIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 640px) {
+  .notif-pref-header,
+  .notif-pref-list,
+  .notif-pref-footer {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .notif-pref-footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .notif-save-btn {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.tsx
+++ b/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { Bell, Loader2, Save, CheckCircle2 } from 'lucide-react';
+import './NotificationPreferences.css';
+
+interface NotificationCategory {
+  key: string;
+  label: string;
+  description: string;
+}
+
+const CATEGORIES: NotificationCategory[] = [
+  {
+    key: 'shipmentUpdates',
+    label: 'Shipment Updates',
+    description: 'Get notified when shipment status changes or milestones are reached',
+  },
+  {
+    key: 'paymentAlerts',
+    label: 'Payment Alerts',
+    description: 'Receive alerts for payment settlements and transaction events',
+  },
+  {
+    key: 'deliveryConfirmations',
+    label: 'Delivery Confirmations',
+    description: 'Be notified when deliveries are confirmed on-chain',
+  },
+  {
+    key: 'systemAnnouncements',
+    label: 'System Announcements',
+    description: 'Platform updates, maintenance notices, and feature announcements',
+  },
+];
+
+type Preferences = Record<string, boolean>;
+
+const NotificationPreferences: React.FC = () => {
+  const [preferences, setPreferences] = useState<Preferences>({
+    shipmentUpdates: true,
+    paymentAlerts: true,
+    deliveryConfirmations: true,
+    systemAnnouncements: false,
+  });
+  const [loading, setLoading] = useState(false);
+  const [successMsg, setSuccessMsg] = useState('');
+
+  const toggle = (key: string) => {
+    setPreferences(prev => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleSave = () => {
+    setLoading(true);
+    setSuccessMsg('');
+    setTimeout(() => {
+      setLoading(false);
+      setSuccessMsg('Preferences saved successfully!');
+      setTimeout(() => setSuccessMsg(''), 3000);
+    }, 1500);
+  };
+
+  return (
+    <div className="notif-pref-container">
+      <div className="notif-pref-header">
+        <Bell className="notif-pref-icon" size={24} />
+        <div>
+          <h2>Notification Preferences</h2>
+          <p>Choose which in-app notifications you want to receive.</p>
+        </div>
+      </div>
+
+      <div className="notif-pref-list">
+        {CATEGORIES.map(({ key, label, description }) => (
+          <div key={key} className="notif-pref-row">
+            <div className="notif-pref-info">
+              <span className="notif-pref-label">{label}</span>
+              <span className="notif-pref-desc">{description}</span>
+            </div>
+            <label className="notif-switch">
+              <input
+                type="checkbox"
+                checked={preferences[key]}
+                onChange={() => toggle(key)}
+                aria-label={`Toggle ${label}`}
+              />
+              <span className="notif-slider round"></span>
+            </label>
+          </div>
+        ))}
+      </div>
+
+      <div className="notif-pref-footer">
+        {successMsg && (
+          <div className="notif-success-toast">
+            <CheckCircle2 size={16} />
+            {successMsg}
+          </div>
+        )}
+        <button
+          className="notif-save-btn"
+          onClick={handleSave}
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <Loader2 className="notif-spinner" size={16} />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Save size={16} />
+              Save Preferences
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationPreferences;

--- a/frontend/src/pages/dashboard/Company/Settings/CompanySettings.tsx
+++ b/frontend/src/pages/dashboard/Company/Settings/CompanySettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { Camera, Save, CheckCircle2, Loader2, Link as LinkIcon, Bell, Building2 } from 'lucide-react';
+import { Camera, Save, CheckCircle2, Loader2, Link as LinkIcon, Building2 } from 'lucide-react';
 import { WalletConnectButton } from '../../../../components/auth/WalletConnectButton/WalletConnectButton';
+import NotificationPreferences from '../../../Settings/NotificationPreferences/NotificationPreferences';
 import './CompanySettings.css';
 
 const CompanySettings: React.FC = () => {
@@ -10,12 +11,6 @@ const CompanySettings: React.FC = () => {
     });
 
     const [logoPreview, setLogoPreview] = useState<string | null>(null);
-
-    const [notifications, setNotifications] = useState({
-        email: true,
-        inApp: true,
-        sms: false,
-    });
 
     const [loading, setLoading] = useState(false);
     const [successMsg, setSuccessMsg] = useState('');
@@ -31,10 +26,6 @@ const CompanySettings: React.FC = () => {
             const url = URL.createObjectURL(file);
             setLogoPreview(url);
         }
-    };
-
-    const toggleNotification = (key: keyof typeof notifications) => {
-        setNotifications(prev => ({ ...prev, [key]: !prev[key] }));
     };
 
     const handleSave = () => {
@@ -113,58 +104,7 @@ const CompanySettings: React.FC = () => {
               </section>
 
               {/* Notification Preferences Section */}
-              <section className="settings-card">
-                  <div className="card-header">
-                      <Bell className="card-icon" size={24} />
-                      <h2>Notification Preferences</h2>
-                  </div>
-                  <div className="card-body">
-                      <div className="toggle-group">
-                          <div className="toggle-info">
-                              <span className="toggle-label">Email Alerts</span>
-                              <span className="toggle-desc">Receive shipment updates via email</span>
-                          </div>
-                          <label className="switch">
-                              <input
-                                  type="checkbox"
-                                  checked={notifications.email}
-                                  onChange={() => toggleNotification('email')}
-                              />
-                              <span className="slider round"></span>
-                          </label>
-                      </div>
-
-                      <div className="toggle-group">
-                          <div className="toggle-info">
-                              <span className="toggle-label">In-App Notifications</span>
-                              <span className="toggle-desc">Show alerts within the dashboard</span>
-                          </div>
-                          <label className="switch">
-                              <input
-                                  type="checkbox"
-                                  checked={notifications.inApp}
-                                  onChange={() => toggleNotification('inApp')}
-                              />
-                              <span className="slider round"></span>
-                          </label>
-                      </div>
-
-                      <div className="toggle-group">
-                          <div className="toggle-info">
-                              <span className="toggle-label">SMS Alerts</span>
-                              <span className="toggle-desc">Receive critical alerts via SMS text</span>
-                          </div>
-                          <label className="switch">
-                              <input
-                                  type="checkbox"
-                                  checked={notifications.sms}
-                                  onChange={() => toggleNotification('sms')}
-                              />
-                              <span className="slider round"></span>
-                          </label>
-                      </div>
-                  </div>
-              </section>
+              <NotificationPreferences />
 
               {/* Connected Wallet Section */}
               <section className="settings-card">


### PR DESCRIPTION
- Create NotificationPreferences component at frontend/src/pages/Settings/NotificationPreferences/
- 4 in-app toggle categories: Shipment Updates, Payment Alerts, Delivery Confirmations, System Announcements
- Save Preferences button with loading and success states
- Replace inline notification toggles in CompanySettings with the new component
- Scoped CSS with notif-* prefix to avoid style collisions

Closes #75