### PR TITLE
[#118] [FE:] Build the Customer active shipments card list

### DIFF
--- a/frontend/src/pages/dashboard/Customer/ActiveShipments/ActiveShipments.test.tsx
+++ b/frontend/src/pages/dashboard/Customer/ActiveShipments/ActiveShipments.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ActiveShipments from './ActiveShipments';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+describe('ActiveShipments', () => {
+  it('renders at least four shipment cards with required fields', () => {
+    render(<ActiveShipments />);
+
+    const cards = screen.getAllByTestId('active-shipment-card');
+    expect(cards.length).toBeGreaterThanOrEqual(4);
+
+    expect(screen.getByText('SHP-2001')).toBeInTheDocument();
+    expect(screen.getByText('In Transit')).toBeInTheDocument();
+    expect(screen.getByText('Singapore')).toBeInTheDocument();
+    expect(screen.getByText('Los Angeles')).toBeInTheDocument();
+    expect(screen.getByText('Feb 28, 2026')).toBeInTheDocument();
+  });
+
+  it('navigates to shipment detail page when track is clicked', () => {
+    render(<ActiveShipments />);
+
+    const firstTrackButton = screen.getAllByRole('button', { name: 'Track' })[0];
+    fireEvent.click(firstTrackButton);
+
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard/shipments/SHP-2001');
+  });
+});

--- a/frontend/src/pages/dashboard/Customer/ActiveShipments/ActiveShipments.tsx
+++ b/frontend/src/pages/dashboard/Customer/ActiveShipments/ActiveShipments.tsx
@@ -36,6 +36,7 @@ const ActiveShipments: React.FC = () => {
         {MOCK_ACTIVE_SHIPMENTS.map((shipment) => (
           <div
             key={shipment.id}
+            data-testid="active-shipment-card"
             className="bg-white border border-[#e5e7eb] rounded-lg p-6 flex flex-col gap-4 transition-shadow hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)]"
           >
             <div className="flex justify-between items-center">
@@ -56,7 +57,7 @@ const ActiveShipments: React.FC = () => {
             <button
               type="button"
               className="bg-[#2563eb] text-white border-none rounded-md px-4 py-2.5 text-sm font-medium cursor-pointer transition-colors hover:bg-[#1d4ed8] active:bg-[#1e40af]"
-              onClick={() => navigate(`/shipments/${shipment.id}`)}
+              onClick={() => navigate(`/dashboard/shipments/${shipment.id}`)}
             >
               Track
             </button>


### PR DESCRIPTION
## Summary
- implement the customer active shipments card list in a responsive grid with four mock shipment cards
- include shipment id, status badge, route, eta, and a track action wired to the shipment detail path
- add coverage for card rendering and track navigation behavior

Closes #118

## Verification
- `pnpm test -- src/pages/dashboard/Customer/ActiveShipments/ActiveShipments.test.tsx` (pass)
- `pnpm run lint` (fails on pre-existing `PaymentHistory` undefined symbols)
- `pnpm run build` (fails on pre-existing `PaymentHistory` / `PaymentDetailModal` issues)
- `pnpm run test` (fails on pre-existing unrelated timeout tests)

Made with [Cursor](https://cursor.com)