### PR TITLE
Feat: Implement the payment status on shipment detail

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import HelpCenter from './pages/HelpCenter/HelpCenter';
 import CreateShipment from './pages/dashboard/Company/CreateShipment/CreateShipment';
 import PaymentHistory from './pages/Payments/PaymentHistory/PaymentHistory';
 import NotificationsPage from './pages/Notifications/NotificationsPage';
+import ShipmentDetail from './pages/ShipmentDetail/ShipmentDetail';
 import DashboardLayout from './components/layout/DashboardLayout';
 import ProtectedRoute from './components/auth/ProtectedRoute/ProtectedRoute';
 import './App.css';
@@ -48,6 +49,10 @@ const router = createBrowserRouter([
           {
             path: '/dashboard/shipments',
             element: <Shipments />,
+          },
+          {
+            path: '/dashboard/shipments/:id',
+            element: <ShipmentDetail />,
           },
           {
             path: '/dashboard/shipments/create',

--- a/frontend/src/pages/ShipmentDetail/PaymentStatus/PaymentStatus.tsx
+++ b/frontend/src/pages/ShipmentDetail/PaymentStatus/PaymentStatus.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { ExternalLink, Wallet, CreditCard, ArrowRightLeft, Hash } from "lucide-react";
+
+export type PaymentStatusType = "pending" | "escrowed" | "released" | "failed";
+
+export interface PaymentData {
+  amount: string;
+  tokenSymbol: string;
+  status: PaymentStatusType;
+  payerAddress: string;
+  payeeAddress: string;
+  transactionHash: string;
+}
+
+export interface PaymentStatusProps {
+  payment?: PaymentData | null;
+}
+
+const PaymentStatus: React.FC<PaymentStatusProps> = ({ payment }) => {
+  const statusStyles: Record<PaymentStatusType, string> = {
+    pending: "bg-yellow-500/20 text-yellow-300 border border-yellow-500/40",
+    escrowed: "bg-blue-500/20 text-blue-300 border border-blue-500/40",
+    released: "bg-green-500/20 text-green-300 border border-green-500/40",
+    failed: "bg-red-500/20 text-red-300 border border-red-500/40",
+  };
+
+  const formatStatus = (status: PaymentStatusType): string =>
+    status.charAt(0).toUpperCase() + status.slice(1);
+
+  const truncateAddress = (address: string): string => {
+    if (address.length <= 12) return address;
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+  };
+
+  const getStellarExplorerUrl = (txHash: string): string =>
+    `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+
+  return (
+    <div className="bg-[rgba(8,40,50,0.4)] border-[1.5px] border-[rgba(0,180,160,0.3)] rounded-3xl px-8 py-12 backdrop-blur-md shadow-[0_8px_32px_rgba(0,0,0,0.3)] mt-8 md:px-5 md:py-8 md:rounded-2xl sm:px-4 sm:py-6">
+      <h2 className="font-['Bebas_Neue',sans-serif] text-[clamp(1.75rem,4vw,2.5rem)] font-normal tracking-[0.04em] leading-[1.2] text-white text-center mb-8">
+        PAYMENT <span className="text-[#00d4c8]">STATUS</span>
+      </h2>
+
+      {payment ? (
+        <div className="bg-[rgba(0,0,0,0.2)] rounded-2xl border border-[rgba(255,255,255,0.05)] overflow-hidden">
+          {/* Payment Amount Header */}
+          <div className="bg-[rgba(0,212,200,0.05)] border-b border-[rgba(0,212,200,0.2)] px-6 py-5 flex items-center justify-between flex-wrap gap-4">
+            <div className="flex items-center gap-4">
+              <div className="bg-[rgba(0,212,200,0.15)] rounded-xl w-12 h-12 flex items-center justify-center">
+                <Wallet className="w-6 h-6 text-[#00d4c8]" />
+              </div>
+              <div>
+                <p className="text-[rgba(255,255,255,0.5)] text-sm m-0 mb-1">Payment Amount</p>
+                <p className="text-white text-2xl font-semibold m-0">
+                  {payment.amount} <span className="text-[#00d4c8]">{payment.tokenSymbol}</span>
+                </p>
+              </div>
+            </div>
+            <span
+              className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold ${statusStyles[payment.status]}`}
+            >
+              <span
+                className={`w-2 h-2 rounded-full ${
+                  payment.status === "pending" ? "bg-yellow-400 animate-pulse" :
+                  payment.status === "escrowed" ? "bg-blue-400 animate-pulse" :
+                  payment.status === "released" ? "bg-green-400" :
+                  "bg-red-400"
+                }`}
+              />
+              {formatStatus(payment.status)}
+            </span>
+          </div>
+
+          {/* Payment Details */}
+          <div className="px-6 py-6 flex flex-col gap-5">
+            {/* Payer Address */}
+            <div className="flex items-start gap-4">
+              <div className="bg-[rgba(0,212,200,0.1)] rounded-lg w-10 h-10 flex items-center justify-center shrink-0">
+                <CreditCard className="w-5 h-5 text-[#00d4c8]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[rgba(255,255,255,0.5)] text-sm m-0 mb-1">Payer Address</p>
+                <p className="text-white text-base font-medium m-0 font-mono" title={payment.payerAddress}>
+                  {truncateAddress(payment.payerAddress)}
+                </p>
+              </div>
+            </div>
+
+            {/* Payee Address */}
+            <div className="flex items-start gap-4">
+              <div className="bg-[rgba(0,212,200,0.1)] rounded-lg w-10 h-10 flex items-center justify-center shrink-0">
+                <ArrowRightLeft className="w-5 h-5 text-[#00d4c8]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[rgba(255,255,255,0.5)] text-sm m-0 mb-1">Payee Address</p>
+                <p className="text-white text-base font-medium m-0 font-mono" title={payment.payeeAddress}>
+                  {truncateAddress(payment.payeeAddress)}
+                </p>
+              </div>
+            </div>
+
+            {/* Transaction Hash */}
+            <div className="flex items-start gap-4">
+              <div className="bg-[rgba(0,212,200,0.1)] rounded-lg w-10 h-10 flex items-center justify-center shrink-0">
+                <Hash className="w-5 h-5 text-[#00d4c8]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[rgba(255,255,255,0.5)] text-sm m-0 mb-1">Transaction Hash</p>
+                <a
+                  href={getStellarExplorerUrl(payment.transactionHash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-[#00d4c8] text-base font-medium font-mono hover:text-[#1fffff] transition-colors group"
+                  title={payment.transactionHash}
+                >
+                  {truncateAddress(payment.transactionHash)}
+                  <ExternalLink className="w-4 h-4 opacity-70 group-hover:opacity-100 transition-opacity" />
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        /* Empty State */
+        <div className="bg-[rgba(0,0,0,0.2)] rounded-2xl border border-[rgba(255,255,255,0.05)] px-8 py-12 flex flex-col items-center text-center">
+          <div className="bg-[rgba(255,255,255,0.05)] rounded-full w-20 h-20 flex items-center justify-center mb-6">
+            <Wallet className="w-10 h-10 text-[rgba(255,255,255,0.3)]" />
+          </div>
+          <h3 className="text-white text-xl font-semibold m-0 mb-2">Payment Not Yet Initiated</h3>
+          <p className="text-[rgba(255,255,255,0.5)] text-base m-0 max-w-md">
+            No payment has been made for this shipment yet. Payment details will appear here once a transaction is initiated.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PaymentStatus;

--- a/frontend/src/pages/ShipmentDetail/ShipmentDetail.tsx
+++ b/frontend/src/pages/ShipmentDetail/ShipmentDetail.tsx
@@ -4,6 +4,7 @@ import ShipmentDetailHeader from "./ShipmentDetailHeader/ShipmentDetailHeader";
 import ShipmentMap from "./ShipmentMap/ShipmentMap";
 import DeliveryProofUpload from "./DeliveryProofUpload/DeliveryProofUpload";
 import DeliveryConfirmation from "../../components/shipment/DeliveryConfirmation/DeliveryConfirmation";
+import PaymentStatus, { PaymentData } from "./PaymentStatus/PaymentStatus";
 
 const ShipmentDetail: React.FC = () => {
   const shipmentHeaderData = {
@@ -18,6 +19,16 @@ const ShipmentDetail: React.FC = () => {
   const handleUpdateStatus = () => { console.log("Update status clicked"); };
   const handleTrack = () => { console.log("Track clicked"); };
 
+  // Mock payment data - set to null to show empty state
+  const mockPaymentData: PaymentData | null = {
+    amount: "1,500.00",
+    tokenSymbol: "XLM",
+    status: "escrowed",
+    payerAddress: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+    payeeAddress: "GCFXHS4GXL6BVUCXBWXGTITROWLVYXQKQLF4YH5O5JT3YZXCYPAFBJZB",
+    transactionHash: "a]b c9d4e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9",
+  };
+
   const mockMilestones: MilestoneDetail[] = [
     { id: "1", name: "Order Confirmed", timestamp: "2026-02-20 09:15 AM EST", location: "New York Distribution Center, NY", blockchainAddress: "GABCD1234567890WXYZ1234567890ABCDEF", status: "completed", notes: "Order successfully confirmed and payment verified on blockchain. Shipment prepared for pickup.", sensorReadings: { temperature: "22°C", humidity: "45%", pressure: "1013 hPa" } },
     { id: "2", name: "Picked Up by Carrier", timestamp: "2026-02-20 02:30 PM EST", location: "New York Distribution Center, NY", blockchainAddress: "GEFGH2345678901YZAB2345678901BCDEFG", status: "completed", notes: "Package picked up by carrier. Driver ID verified and logged on-chain.", sensorReadings: { temperature: "21°C", humidity: "48%", pressure: "1012 hPa" } },
@@ -30,19 +41,19 @@ const ShipmentDetail: React.FC = () => {
 
   return (
     <div className="relative min-h-screen w-full bg-[radial-gradient(ellipse_at_50%_0%,#0a3d3a_0%,#061e20_35%,#020d10_70%,#000_100%)] px-8 py-16 md:px-4 md:py-8 sm:px-3 sm:py-6 font-sans">
-      <div className="max-w-[1200px] mx-auto relative z-10">
+      <div className="max-w-300 mx-auto relative z-10">
         {/* Page header */}
         <div className="text-center mb-16 md:mb-10">
           <h1 className="font-['Bebas_Neue',sans-serif] text-[clamp(2.5rem,7vw,5rem)] font-normal tracking-[0.04em] leading-[1.1] text-white m-0 mb-4">
             SHIPMENT <span className="text-[#00d4c8]">DETAILS</span>
           </h1>
-          <p className="text-[clamp(0.95rem,2vw,1.1rem)] font-light leading-[1.7] text-[rgba(200,230,240,0.75)] max-w-[600px] mx-auto">
+          <p className="text-[clamp(0.95rem,2vw,1.1rem)] font-light leading-[1.7] text-[rgba(200,230,240,0.75)] max-w-150 mx-auto">
             Track your shipment's journey with blockchain-verified milestones
           </p>
         </div>
 
         {/* Content card */}
-        <div className="bg-[rgba(8,40,50,0.4)] border-[1.5px] border-[rgba(0,180,160,0.3)] rounded-3xl p-8 backdrop-blur-[12px] shadow-[0_8px_32px_rgba(0,0,0,0.3)] md:p-5 md:rounded-2xl sm:p-4">
+        <div className="bg-[rgba(8,40,50,0.4)] border-[1.5px] border-[rgba(0,180,160,0.3)] rounded-3xl p-8 backdrop-blur-md shadow-[0_8px_32px_rgba(0,0,0,0.3)] md:p-5 md:rounded-2xl sm:p-4">
           <ShipmentMap 
             origin={shipmentHeaderData.originAddress} 
             destination={shipmentHeaderData.destinationAddress} 
@@ -63,6 +74,7 @@ const ShipmentDetail: React.FC = () => {
           <MilestoneTimeline milestones={mockMilestones} />
         </div>
 
+        <PaymentStatus payment={mockPaymentData} />
         <DeliveryProofUpload />
         <DeliveryConfirmation
           shipmentId={shipmentHeaderData.shipmentId}


### PR DESCRIPTION
## Summary

This pr closes #127  

I have created the PaymentStatus component and integrated it into the ShipmentDetail page. The component displays:

- A payment card with amount and token symbol (e.g., "1,500.00 XLM")
- Payment status badge with appropriate colors (Pending/yellow, Escrowed/blue, Released/green, Failed/red)
- Truncated payer and payee addresses with full address shown on hover
- Transaction hash as a clickable link that opens in a new tab to the Stellar explorer
- An empty state with "Payment Not Yet Initiated" message when no payment data exists

## Demo
<img width="1171" height="475" alt="image" src="https://github.com/user-attachments/assets/f1687a57-52b2-489d-ab01-759c62bac6f9" />
