### PR TITLE
fix: validate auth token format before attaching to requests

### DIFF
--- a/frontend/src/services/api/interceptors/authInterceptor.ts
+++ b/frontend/src/services/api/interceptors/authInterceptor.ts
@@ -1,12 +1,38 @@
 import { AxiosInstance, InternalAxiosRequestConfig } from "axios";
 
+/**
+ * Validates that a string looks like a JWT (3 dot-separated base64 segments).
+ * This is a structural check only — it does NOT verify the signature.
+ */
+const isValidJWT = (token: string): boolean => {
+    if (!token || token.trim().length === 0) {
+        return false;
+    }
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+        return false;
+    }
+    // Each part should be non-empty and contain only valid base64url chars
+    const base64urlPattern = /^[A-Za-z0-9_-]+$/;
+    return parts.every((part) => base64urlPattern.test(part) && part.length > 0);
+};
+
 export const setupAuthInterceptor = (client: AxiosInstance) => {
     client.interceptors.request.use(
         (config: InternalAxiosRequestConfig) => {
             const token = localStorage.getItem("authToken");
 
             if (token && config.headers) {
-                config.headers.Authorization = `Bearer ${token}`;
+                if (isValidJWT(token)) {
+                    config.headers.Authorization = `Bearer ${token}`;
+                } else {
+                    // Token is malformed or corrupted — clear it to prevent 401 loops
+                    localStorage.removeItem("authToken");
+                    // Only redirect if not already on login page to avoid infinite loops
+                    if (!window.location.pathname.includes("/login")) {
+                        window.location.href = "/login";
+                    }
+                }
             }
 
             return config;


### PR DESCRIPTION
## Summary
Closes #181

Adds basic JWT validation to the auth interceptor before attaching tokens to outgoing requests.

## Changes
- Added `isValidJWT()` helper to validate token structure (3 dot-separated base64url segments)
- Malformed/corrupted tokens are cleared from localStorage immediately
- User is redirected to `/login` when token validation fails
- Redirect loop prevention when already on `/login.`

## Testing
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] `pnpm run dev` starts without errors
