### PR TITLE
fix: rename proof upload field from notes to recipientSignatureName

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+# TypeScript build cache
+*.tsbuildinfo
+
+# Vite build artifacts
+vite.config.js
+vite.config.ts.timestamp-*

--- a/frontend/src/services/api/endpoints/shipments.ts
+++ b/frontend/src/services/api/endpoints/shipments.ts
@@ -71,10 +71,10 @@ export const shipmentApi = {
         return res.data.data;
     },
 
-    uploadProof: async (id: string, file: File, notes?: string): Promise<Shipment> => {
+        uploadProof: async (id: string, file: File, recipientSignatureName: string): Promise<Shipment> => {
         const form = new FormData();
         form.append("file", file);
-        if (notes) form.append("notes", notes);
+        form.append("recipientSignatureName", recipientSignatureName);
         const res = await apiClient.post<{ data: Shipment }>(`/shipments/${id}/proof`, form, {
             headers: { "Content-Type": "multipart/form-data" },
         });


### PR DESCRIPTION
## Summary
Closes #179

Updates the proof upload API method to use the correct field name expected by the backend.

## Changes
- Renamed `uploadProof` parameter from `notes?: string` to `recipientSignatureName: string.`
- Changed FormData field key from `"notes"` to `"recipientSignatureName"`
- Made parameter required (no longer optional) per backend contract

## Testing
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] `pnpm run dev` starts without errors
