### PR TITLE
fix(api,types): fix multipart upload headers and expose Stellar token…

### DIFF
--- a/frontend/src/pages/ShipmentDetail/PaymentStatus/PaymentStatus.tsx
+++ b/frontend/src/pages/ShipmentDetail/PaymentStatus/PaymentStatus.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ExternalLink, Wallet, CreditCard, ArrowRightLeft, Hash } from "lucide-react";
+import { ExternalLink, Wallet, CreditCard, ArrowRightLeft, Hash, Coins } from "lucide-react";
 
 export type PaymentStatusType = "pending" | "escrowed" | "released" | "failed";
 
@@ -10,6 +10,10 @@ export interface PaymentData {
   payerAddress: string;
   payeeAddress: string;
   transactionHash: string;
+  /** Stellar NFT token ID set by the backend after tokenization */
+  stellarTokenId?: string;
+  /** Stellar transaction hash for the tokenization transaction */
+  stellarTxHash?: string;
 }
 
 export interface PaymentStatusProps {
@@ -118,6 +122,43 @@ const PaymentStatus: React.FC<PaymentStatusProps> = ({ payment }) => {
                 </a>
               </div>
             </div>
+
+            {/* Stellar Token ID (set after tokenization) */}
+            {payment.stellarTokenId && (
+              <div className="flex items-start gap-4">
+                <div className="bg-[rgba(0,212,200,0.1)] rounded-lg w-10 h-10 flex items-center justify-center shrink-0">
+                  <Coins className="w-5 h-5 text-[#00d4c8]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[rgba(255,255,255,0.5)] text-sm m-0 mb-1">Stellar Token ID</p>
+                  <p className="text-white text-base font-medium m-0 font-mono" title={payment.stellarTokenId}>
+                    {truncateAddress(payment.stellarTokenId)}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Stellar Tokenization Tx Hash */}
+            {payment.stellarTxHash && (
+              <div className="flex items-start gap-4">
+                <div className="bg-[rgba(0,212,200,0.1)] rounded-lg w-10 h-10 flex items-center justify-center shrink-0">
+                  <ExternalLink className="w-5 h-5 text-[#00d4c8]" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[rgba(255,255,255,0.5)] text-sm m-0 mb-1">Tokenization Tx</p>
+                  <a
+                    href={getStellarExplorerUrl(payment.stellarTxHash)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 text-[#00d4c8] text-base font-medium font-mono hover:text-[#1fffff] transition-colors group"
+                    title={payment.stellarTxHash}
+                  >
+                    {truncateAddress(payment.stellarTxHash)}
+                    <ExternalLink className="w-4 h-4 opacity-70 group-hover:opacity-100 transition-opacity" />
+                  </a>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/frontend/src/services/api/endpoints/shipments.ts
+++ b/frontend/src/services/api/endpoints/shipments.ts
@@ -20,6 +20,10 @@ export interface Shipment {
     offChainMetadata?: Record<string, unknown>;
     createdAt: string;
     updatedAt: string;
+    /** Stellar NFT token ID set by the backend after tokenization */
+    stellarTokenId?: string;
+    /** Stellar transaction hash for the tokenization transaction */
+    stellarTxHash?: string;
 }
 
 export interface PaginatedShipments {
@@ -75,9 +79,9 @@ export const shipmentApi = {
         const form = new FormData();
         form.append("file", file);
         if (notes) form.append("notes", notes);
-        const res = await apiClient.post<{ data: Shipment }>(`/shipments/${id}/proof`, form, {
-            headers: { "Content-Type": "multipart/form-data" },
-        });
+        // Do NOT set Content-Type manually — the browser/axios must set it
+        // automatically so the multipart boundary is included correctly.
+        const res = await apiClient.post<{ data: Shipment }>(`/shipments/${id}/proof`, form);
         return res.data.data;
     },
 


### PR DESCRIPTION
…ization fields

Closes #200
Closes #199

---

## Issue #200 — Fix multipart upload headers for proof upload

**Problem:**
shipmentApi.uploadProof was explicitly setting:
  headers: { 'Content-Type': 'multipart/form-data' }

When you manually set Content-Type for a multipart/form-data request, the browser (or axios) never appends the required boundary parameter to the header value. The server then cannot parse the multipart body because it does not know where one part ends and the next begins, causing all proof uploads to fail with a 400 or parse error on the backend.

**Fix (frontend/src/services/api/endpoints/shipments.ts):**
- Removed the explicit headers config object from the apiClient.post call in uploadProof.
- When FormData is passed directly to axios, axios detects it and lets the browser set 'Content-Type: multipart/form-data; boundary=<generated>' automatically with the correct boundary token.
- Added a comment explaining why the header must NOT be set manually, so future contributors do not reintroduce the bug.

---

## Issue #199 — Expose stellarTokenId and stellarTxHash in Shipment type

**Problem:**
The backend sets stellarTokenId and stellarTxHash on a shipment once it has been tokenized on Stellar Soroban. These fields were completely absent from the frontend Shipment interface and the ShipmentDetail PaymentStatus UI, so tokenization data was silently dropped and users had no way to verify the on-chain token or transaction.

**Fix — Type layer (frontend/src/services/api/endpoints/shipments.ts):**
- Added optional fields stellarTokenId?: string and stellarTxHash?: string to the Shipment interface with JSDoc comments explaining their origin.
- Both fields are optional (?) because they are only populated after the backend completes the tokenization step; pre-tokenization shipments will not have them.

**Fix — UI layer (frontend/src/pages/ShipmentDetail/PaymentStatus/PaymentStatus.tsx):**
- Extended the local PaymentData interface with matching optional fields stellarTokenId?: string and stellarTxHash?: string so consumers can pass real Shipment data through.
- Added a 'Stellar Token ID' row (with Coins icon from lucide-react) that renders the truncated token ID when present.
- Added a 'Tokenization Tx' row (with ExternalLink icon) that renders a clickable link to stellar.expert when the tokenization hash is present.
- Both new rows are conditionally rendered only when the field is non-null, so the component remains unchanged for shipments that have not yet been tokenized.
- Imported the Coins icon from lucide-react (already a project dependency).

No new dependencies introduced. No tests broken. TypeScript strict mode passes with no diagnostics on both changed files.