### PR TITLE
fix: resolve duplicate imports and corrupted merges in App.tsx and StatusBadge

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.0.0",
     "recharts": "^3.7.0"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-router-dom:
         specifier: ^7.0.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1344,6 +1347,11 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
+  goober@2.1.19:
+    resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1680,6 +1688,13 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -3208,6 +3223,10 @@ snapshots:
 
   globals@16.5.0: {}
 
+  goober@2.1.19(csstype@3.2.3):
+    dependencies:
+      csstype: 3.2.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3495,6 +3514,13 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-hot-toast@2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      csstype: 3.2.3
+      goober: 2.1.19(csstype@3.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-is@17.0.2: {}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,42 +5,23 @@ import Login from './pages/auth/Login/Login';
 import ForgotPassword from './pages/auth/ForgotPassword/ForgotPassword';
 import CompanyDashboard from './pages/dashboard/Company/CompanyDashboard';
 import Shipments from './pages/Shipments/Shipments';
-import ShipmentDetail from './pages/Shipment/ShipmentDetail';
+import ShipmentDetail from './pages/ShipmentDetail/ShipmentDetail';
 import BlockchainLedger from './pages/BlockchainLedger/BlockchainLedger';
 import Settlements from './pages/Settlements/Settlements';
 import Analytics from './pages/Analytics/Analytics';
-import Settings from './pages/Settings/Settings';
 import UserManagement from './pages/dashboard/Company/UserManagement/UserManagement';
 import CompanySettings from './pages/dashboard/Company/Settings/CompanySettings';
 import HelpCenter from './pages/HelpCenter/HelpCenter';
 import CreateShipment from './pages/dashboard/Company/CreateShipment/CreateShipment';
+import PaymentHistory from './pages/Payments/PaymentHistory/PaymentHistory';
+import NotificationsPage from './pages/Notifications/NotificationsPage';
+import CustomerProfile from './pages/dashboard/Customer/Profile/CustomerProfile';
+import ShipmentHistory from './pages/dashboard/Customer/ShipmentHistory/ShipmentHistory';
 import DashboardLayout from './components/layout/DashboardLayout';
 import ProtectedRoute from './components/auth/ProtectedRoute/ProtectedRoute';
+import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
+import PaginationDemo from './pages/ComponentDemos/PaginationDemo/PaginationDemo';
 import './App.css';
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import Home from "./pages/Home/Home";
-import Signup from "./pages/auth/Signup/Signup";
-import Login from "./pages/auth/Login/Login";
-import ForgotPassword from "./pages/auth/ForgotPassword/ForgotPassword";
-import CompanyDashboard from "./pages/dashboard/Company/CompanyDashboard";
-import Shipments from "./pages/Shipments/Shipments";
-import ShipmentDetail from "./pages/ShipmentDetail/ShipmentDetail";
-import BlockchainLedger from "./pages/BlockchainLedger/BlockchainLedger";
-import Settlements from "./pages/Settlements/Settlements";
-import Analytics from "./pages/Analytics/Analytics";
-import UserManagement from "./pages/dashboard/Company/UserManagement/UserManagement";
-import CompanySettings from "./pages/dashboard/Company/Settings/CompanySettings";
-import HelpCenter from "./pages/HelpCenter/HelpCenter";
-import CreateShipment from "./pages/dashboard/Company/CreateShipment/CreateShipment";
-import PaymentHistory from "./pages/Payments/PaymentHistory/PaymentHistory";
-import NotificationsPage from "./pages/Notifications/NotificationsPage";
-import CustomerProfile from "./pages/dashboard/Customer/Profile/CustomerProfile";
-import ShipmentHistory from "./pages/dashboard/Customer/ShipmentHistory/ShipmentHistory";
-import DashboardLayout from "./components/layout/DashboardLayout";
-import ProtectedRoute from "./components/auth/ProtectedRoute/ProtectedRoute";
-import ErrorBoundary from "./components/ErrorBoundary/ErrorBoundary";
-import PaginationDemo from "./pages/ComponentDemos/PaginationDemo/PaginationDemo";
-import "./App.css";
 
 const router = createBrowserRouter([
   {
@@ -83,7 +64,6 @@ const router = createBrowserRouter([
           },
           {
             path: '/dashboard/shipments/create',
-            path: "/dashboard/shipments/create",
             element: <CreateShipment />,
           },
           {

--- a/frontend/src/components/ui/StatusBadge/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge/StatusBadge.tsx
@@ -1,60 +1,15 @@
 import React from 'react';
-import './StatusBadge.css';
+import { getStatusDisplayLabel, getStatusBadgeClass } from '../../../utils/shipmentStatus';
 
-export type ShipmentStatus = 
-  | 'In Transit'
-  | 'Delivered'
-  | 'Pending Approval'
-  | 'Cancelled'
-  | 'Picked Up'
-  | 'At Checkpoint'
-  | 'Out for Delivery';
-
-export interface StatusBadgeProps {
-  status: ShipmentStatus;
-  className?: string;
-}
-
-export const StatusBadge: React.FC<StatusBadgeProps> = ({ 
-  status, 
-  className = '' 
-}) => {
-  const getStatusClassName = (status: ShipmentStatus): string => {
-    switch (status) {
-      case 'In Transit':
-      case 'Picked Up':
-      case 'At Checkpoint':
-      case 'Out for Delivery':
-        return 'status-in-transit';
-      case 'Delivered':
-        return 'status-delivered';
-      case 'Pending Approval':
-        return 'status-pending';
-      case 'Cancelled':
-        return 'status-cancelled';
-      default:
-        return 'status-in-transit';
-    }
-  };
-
-  return (
-    <span 
-      className={`status-badge ${getStatusClassName(status)} ${className}`}
-      aria-label={`Shipment status: ${status}`}
-    >
-      {status}
 export interface StatusBadgeProps {
   status: string;
   className?: string;
 }
 
-import { getStatusDisplayLabel, getStatusBadgeClass } from '../../../utils/shipmentStatus';
-
 export const StatusBadge: React.FC<StatusBadgeProps> = ({
   status,
   className = ''
 }) => {
-  // Use shared mapping for display and classes
   const label = getStatusDisplayLabel(status);
   const classes = getStatusBadgeClass(status);
 


### PR DESCRIPTION
## Summary
Fixes corrupted merge artifacts in `main` that broke the dev server after recent PR merges.

## Changes
- **App.tsx**: Removed duplicate `createBrowserRouter` import, duplicate page imports, duplicate routes, and broken object with dual `path` keys
- **StatusBadge.tsx**: Removed stacked duplicate component code (two versions merged into one file), kept the version using shared `shipmentStatus` utils

## Testing
- `pnpm install` completes successfully
- `pnpm run dev` starts without errors
- App loads at `http://localhost:5173/`

## Notes
These issues were introduced by a fast-forward merge that stacked conflicting code blocks instead of resolving them properly.