### PR TITLE
fix: standardize ShipmentStatus type usage across API and UI (#218)

### DIFF
--- a/frontend/src/api/shipmentApi.ts
+++ b/frontend/src/api/shipmentApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { ShipmentStatus } from '../components/ui/StatusBadge/StatusBadge';
+import type { ShipmentStatus } from '../services/api/endpoints/shipments';
 
 export interface Shipment {
   id: string;
@@ -52,10 +52,10 @@ interface BackendResponse {
 }
 
 const STATUS_MAP: Record<string, ShipmentStatus> = {
-  CREATED: 'Pending Approval',
-  IN_TRANSIT: 'In Transit',
-  DELIVERED: 'Delivered',
-  CANCELLED: 'Cancelled',
+  CREATED: 'CREATED',
+  IN_TRANSIT: 'IN_TRANSIT',
+  DELIVERED: 'DELIVERED',
+  CANCELLED: 'CANCELLED',
 };
 
 const normalizeShipment = (shipment: BackendShipment): Shipment => {
@@ -66,7 +66,7 @@ const normalizeShipment = (shipment: BackendShipment): Shipment => {
     status:
       STATUS_MAP[String(shipment.status).toUpperCase()] ??
       (shipment.status as ShipmentStatus) ??
-      'Pending Approval',
+      'CREATED',
     createdAt: String(shipment.createdAt),
     deliveryProof: shipment.deliveryProof?.url
       ? {


### PR DESCRIPTION
## Summary
Fixes #218 — Standardizes ShipmentStatus type usage and resolves type conflicts between API and UI layers.

## Changes
- **StatusBadge.tsx**: Removed corrupted duplicate component, now uses `shipmentStatus.ts` utils
- **shipmentApi.ts**: Imports `ShipmentStatus` from API layer (`shipments.ts`) instead of UI layer
- **shipmentApi.ts**: Fixed `STATUS_MAP` to use API enum values (`CREATED`, `IN_TRANSIT`, etc.)
- **App.tsx**: Resolved merge corruption (duplicate imports/routes)

## Testing
- `pnpm run dev` starts successfully
- TypeScript compiles without errors
- App loads at `http://localhost:5173/`