### PR TITLE
feat: implement issues #333, #339, #340, #341 — a11y live regions, AR…

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -67,6 +67,7 @@ const DashboardLayout: React.FC = () => {
           <button
             className="ml-auto flex lg:hidden bg-transparent border-none text-slate-400 cursor-pointer"
             onClick={closeSidebar}
+            aria-label="Close sidebar"
           >
             <X size={20} />
           </button>

--- a/frontend/src/components/layout/TopHeader/TopHeader.tsx
+++ b/frontend/src/components/layout/TopHeader/TopHeader.tsx
@@ -33,6 +33,7 @@ const TopHeader: React.FC<TopHeaderProps> = ({ toggleSidebar }) => {
               type="text"
               className="w-full border-none outline-none bg-transparent text-gray-900 dark:text-white text-sm placeholder:text-gray-400 dark:placeholder:text-slate-500"
               placeholder="Search shipment ID..."
+              aria-label="Search shipment ID"
             />
           </label>
         </div>
@@ -44,6 +45,7 @@ const TopHeader: React.FC<TopHeaderProps> = ({ toggleSidebar }) => {
           <button
             onClick={() => navigate("/dashboard/profile")}
             className="w-9 h-9 rounded-full bg-gray-100 dark:bg-[#1e2433] border border-gray-300 dark:border-slate-700 flex items-center justify-center text-gray-500 dark:text-slate-400 hover:text-gray-900 dark:hover:text-white hover:border-teal-500 dark:hover:border-[#62ffff] transition-colors cursor-pointer"
+            aria-label="View profile"
             title="Profile"
           >
             <User size={18} />

--- a/frontend/src/components/notifications/NotificationDropdown/NotificationDropdown.test.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown/NotificationDropdown.test.tsx
@@ -15,7 +15,7 @@ describe('NotificationDropdown', () => {
 
     renderWithRouter(<NotificationDropdown />);
 
-    const bell = screen.getByLabelText('Notifications');
+    const bell = screen.getByLabelText(/^Notifications/);
     await user.click(bell);
 
     expect(screen.getByText('Notifications')).toBeInTheDocument();
@@ -34,7 +34,7 @@ describe('NotificationDropdown', () => {
 
   it('renders the bell icon with unread badge', () => {
     renderWithRouter(<NotificationDropdown />);
-    const bellButton = screen.getByLabelText('Notifications');
+    const bellButton = screen.getByLabelText(/^Notifications/);
     expect(bellButton).toBeInTheDocument();
 
     const badge = screen.getByText('3');
@@ -44,7 +44,7 @@ describe('NotificationDropdown', () => {
   it('renders the bell icon with unread badge', () => {
     renderWithRouter(<NotificationDropdown />);
     
-    const bellButton = screen.getByLabelText('Notifications');
+    const bellButton = screen.getByLabelText(/^Notifications/);
     expect(bellButton).toBeInTheDocument();
     
     const badge = screen.getByText('3');
@@ -54,7 +54,7 @@ describe('NotificationDropdown', () => {
   it('opens dropdown when bell icon is clicked', () => {
     renderWithRouter(<NotificationDropdown />);
     
-    const bellButton = screen.getByLabelText('Notifications');
+    const bellButton = screen.getByLabelText(/^Notifications/);
     fireEvent.click(bellButton);
     
     expect(screen.getByText('Notifications')).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe('NotificationDropdown', () => {
   it('displays 5 notifications in the dropdown', () => {
     renderWithRouter(<NotificationDropdown />);
     
-    const bellButton = screen.getByLabelText('Notifications');
+    const bellButton = screen.getByLabelText(/^Notifications/);
     fireEvent.click(bellButton);
     
     expect(screen.getByText(/Shipment #SH-2024-001 has been delivered successfully/)).toBeInTheDocument();
@@ -75,7 +75,7 @@ describe('NotificationDropdown', () => {
   it('closes dropdown when close button is clicked', () => {
     renderWithRouter(<NotificationDropdown />);
     
-    const bellButton = screen.getByLabelText('Notifications');
+    const bellButton = screen.getByLabelText(/^Notifications/);
     fireEvent.click(bellButton);
     
     const closeButton = screen.getByLabelText('Close notifications');
@@ -87,7 +87,7 @@ describe('NotificationDropdown', () => {
   it('closes dropdown when ESC key is pressed', () => {
     renderWithRouter(<NotificationDropdown />);
     
-    const bellButton = screen.getByLabelText('Notifications');
+    const bellButton = screen.getByLabelText(/^Notifications/);
     fireEvent.click(bellButton);
     
     expect(screen.getByText('View All Notifications')).toBeInTheDocument();

--- a/frontend/src/components/notifications/NotificationDropdown/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown/NotificationDropdown.tsx
@@ -66,7 +66,7 @@ export const NotificationDropdown: React.FC = () => {
       <button
         className="relative flex items-center justify-center w-[34px] h-[34px] rounded-lg bg-[#07090d] text-white border-none cursor-pointer transition-all hover:bg-[#1e2433]"
         onClick={() => setIsOpen(!isOpen)}
-        aria-label="Notifications"
+        aria-label={unreadCount > 0 ? `Notifications — ${unreadCount} unread` : "Notifications"}
         aria-haspopup="true"
         aria-expanded={isOpen}
       >

--- a/frontend/src/components/notifications/Toast/Toast.test.tsx
+++ b/frontend/src/components/notifications/Toast/Toast.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { ToastProvider, useToast } from "../../../context/ToastContext";
+import { LiveRegionProvider } from "../../../context/LiveRegionContext";
 import { BrowserRouter } from "react-router-dom";
 
 // Helper component to trigger toasts during testing
@@ -17,7 +18,9 @@ const TestComponent = () => {
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
     <BrowserRouter>
-      <ToastProvider>{ui}</ToastProvider>
+      <LiveRegionProvider>
+        <ToastProvider>{ui}</ToastProvider>
+      </LiveRegionProvider>
     </BrowserRouter>,
   );
 };
@@ -38,9 +41,8 @@ describe("Toast System", () => {
     fireEvent.click(screen.getByText("Show Toast"));
     expect(screen.getByText("Test Message")).toBeInTheDocument();
 
-    // Fast-forward 5 seconds
     act(() => {
-      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(8000);
     });
 
     expect(screen.queryByText("Test Message")).not.toBeInTheDocument();
@@ -51,7 +53,7 @@ describe("Toast System", () => {
     renderWithProviders(<TestComponent />);
 
     fireEvent.click(screen.getByText("Show Toast"));
-    const closeButton = screen.getByRole("button", { name: "" }); // The X icon button
+    const closeButton = screen.getByRole("button", { name: "Dismiss notification" });
 
     fireEvent.click(closeButton);
 

--- a/frontend/src/components/notifications/Toast/Toast.tsx
+++ b/frontend/src/components/notifications/Toast/Toast.tsx
@@ -55,6 +55,7 @@ export const Toast: React.FC<ToastProps> = ({
           e.stopPropagation();
           onClose();
         }}
+        aria-label="Dismiss notification"
         className="p-1 ml-4 rounded-full hover:bg-white/10 transition-colors"
       >
         <X className="w-4 h-4 text-secondary" />

--- a/frontend/src/context/LiveRegionContext.tsx
+++ b/frontend/src/context/LiveRegionContext.tsx
@@ -1,0 +1,77 @@
+import React, { createContext, useContext, useState, useCallback, useRef } from "react";
+
+interface LiveRegionContextType {
+  announce: (message: string, priority?: "polite" | "assertive") => void;
+}
+
+const LiveRegionContext = createContext<LiveRegionContextType | undefined>(undefined);
+
+export const LiveRegionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [politeMessage, setPoliteMessage] = useState("");
+  const [assertiveMessage, setAssertiveMessage] = useState("");
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const announce = useCallback((message: string, priority: "polite" | "assertive" = "polite") => {
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+
+    const setter = priority === "assertive" ? setAssertiveMessage : setPoliteMessage;
+    setter("");
+    requestAnimationFrame(() => {
+      setter(message);
+    });
+
+    clearTimerRef.current = setTimeout(() => {
+      setPoliteMessage("");
+      setAssertiveMessage("");
+    }, 7000);
+  }, []);
+
+  return (
+    <LiveRegionContext.Provider value={{ announce }}>
+      {children}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        role="status"
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          padding: 0,
+          margin: "-1px",
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
+          borderWidth: 0,
+        }}
+      >
+        {politeMessage}
+      </div>
+      <div
+        aria-live="assertive"
+        aria-atomic="true"
+        role="alert"
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          padding: 0,
+          margin: "-1px",
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
+          borderWidth: 0,
+        }}
+      >
+        {assertiveMessage}
+      </div>
+    </LiveRegionContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useLiveRegion = () => {
+  const context = useContext(LiveRegionContext);
+  if (!context) throw new Error("useLiveRegion must be used within a LiveRegionProvider");
+  return context;
+};

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from "react";
 import { Toast } from "../components/notifications/Toast/Toast";
+import { useLiveRegion } from "./LiveRegionContext";
 
 export type ToastType = "success" | "error" | "info" | "warning";
 
@@ -21,17 +22,19 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const { announce } = useLiveRegion();
 
   const addToast = useCallback(
     (message: string, type: ToastType, navigateTo?: string) => {
       const id = Math.random().toString(36).substring(2, 9);
       setToasts((prev) => {
         const newList = [...prev, { id, type, message, navigateTo }];
-        // Keep only the latest 3
         return newList.slice(-3);
       });
+      const priority = type === "error" ? "assertive" : "polite";
+      announce(message, priority);
     },
-    [],
+    [announce],
   );
 
   const removeToast = useCallback((id: string) => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/react";
 import "./index.css";
 import App from "./App.tsx";
 import { ToastProvider } from "./context/ToastContext.tsx";
+import { LiveRegionProvider } from "./context/LiveRegionContext.tsx";
 
 if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
@@ -25,8 +26,10 @@ if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ToastProvider>
-      <App />
-    </ToastProvider>
+    <LiveRegionProvider>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </LiveRegionProvider>
   </StrictMode>,
 );

--- a/frontend/src/pages/Notifications/NotificationsPage.tsx
+++ b/frontend/src/pages/Notifications/NotificationsPage.tsx
@@ -159,6 +159,7 @@ const NotificationsPage = () => {
           )}
           <button
             className="w-9 h-9 rounded-md bg-transparent border border-[#374151] flex items-center justify-center cursor-pointer transition-all text-[#6b7280] hover:bg-[#374151] hover:border-[#4b5563] hover:text-white"
+            aria-label="Mark as read"
             onClick={(e) => { e.stopPropagation(); handleNotificationClick(notification.id); }}
           >
             <Check size={16} />
@@ -268,6 +269,7 @@ const NotificationsPage = () => {
                     className="px-5 py-2.5 bg-[#1f2937] border border-[#374151] rounded-lg text-[#9ca3af] text-sm cursor-pointer transition-all hover:not-disabled:bg-[#374151] hover:not-disabled:border-[#4b5563] hover:not-disabled:text-white disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                     disabled={currentPage === 1}
+                    aria-label="Previous page"
                   >
                     Previous
                   </button>
@@ -276,6 +278,7 @@ const NotificationsPage = () => {
                     className="px-5 py-2.5 bg-[#1f2937] border border-[#374151] rounded-lg text-[#9ca3af] text-sm cursor-pointer transition-all hover:not-disabled:bg-[#374151] hover:not-disabled:border-[#4b5563] hover:not-disabled:text-white disabled:opacity-50 disabled:cursor-not-allowed"
                     onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                     disabled={currentPage === totalPages}
+                    aria-label="Next page"
                   >
                     Next
                   </button>

--- a/frontend/src/pages/Settlements/Settlements.tsx
+++ b/frontend/src/pages/Settlements/Settlements.tsx
@@ -185,6 +185,7 @@ export default function Settlements() {
                 setFilterStatus(e.target.value as SettlementStatus | "ALL");
                 setCurrentPage(1);
               }}
+              aria-label="Filter by settlement status"
               className="appearance-none bg-[rgba(19,186,186,0.1)] border border-[rgba(98,255,255,0.2)] text-text-primary px-3.5 py-2 pr-9 rounded-lg text-sm font-medium cursor-pointer outline-none hover:border-[#62ffff] hover:bg-[rgba(19,186,186,0.15)] transition-colors max-md:w-full"
             >
               <option value="ALL">All Status</option>
@@ -199,15 +200,18 @@ export default function Settlements() {
               className="absolute right-3 pointer-events-none text-text-secondary rotate-90"
             />
           </div>
-          <span
+          <button
+            type="button"
             className="inline-flex items-center gap-2 appearance-none bg-[rgba(19,186,186,0.1)] border border-[rgba(98,255,255,0.2)] text-text-primary px-3.5 py-2 pr-9 rounded-lg text-sm font-medium cursor-pointer outline-none hover:border-[#62ffff] hover:bg-[rgba(19,186,186,0.15)] transition-colors max-md:w-full max-md:justify-center"
             onClick={() => setSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
+            aria-label={`Sort by date ${sortOrder === "desc" ? "newest first" : "oldest first"}`}
+            aria-pressed={sortOrder === "desc"}
           >
             Date <ArrowUpDown size={14} />
             <span className="text-text-secondary max-md:hidden">
               {sortOrder === "desc" ? "Newest" : "Oldest"}
             </span>
-          </span>
+          </button>
         </div>
       </div>
 
@@ -244,8 +248,9 @@ export default function Settlements() {
                   <th
                     className={`${thClass} cursor-pointer select-none`}
                     onClick={() => setSortOrder((prev) => (prev === "desc" ? "asc" : "desc"))}
+                    aria-sort={sortOrder === "desc" ? "descending" : "ascending"}
                   >
-                    <span className="inline-flex items-center gap-2">Date <ArrowUpDown size={14} /></span>
+                    <span className="inline-flex items-center gap-2">Date <ArrowUpDown size={14} aria-hidden="true" /></span>
                   </th>
                   <th className={thClass}>Shipment ID</th>
                   <th className={thClass}>Amount</th>
@@ -322,6 +327,7 @@ export default function Settlements() {
               <button
                 onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
                 disabled={currentPage === 1}
+                aria-label="Previous page"
                 className="bg-transparent border border-[rgba(98,255,255,0.2)] text-text-primary px-3 py-2 rounded-md text-sm font-medium cursor-pointer flex items-center justify-center min-w-9 transition-all hover:not-disabled:bg-[rgba(98,255,255,0.1)] hover:not-disabled:border-[#62ffff] hover:not-disabled:text-[#62ffff] disabled:opacity-30 disabled:cursor-not-allowed"
               >
                 <ChevronLeft size={16} />
@@ -341,6 +347,7 @@ export default function Settlements() {
               <button
                 onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
                 disabled={currentPage === totalPages}
+                aria-label="Next page"
                 className="bg-transparent border border-[rgba(98,255,255,0.2)] text-text-primary px-3 py-2 rounded-md text-sm font-medium cursor-pointer flex items-center justify-center min-w-9 transition-all hover:not-disabled:bg-[rgba(98,255,255,0.1)] hover:not-disabled:border-[#62ffff] hover:not-disabled:text-[#62ffff] disabled:opacity-30 disabled:cursor-not-allowed"
               >
                 <ChevronRight size={16} />


### PR DESCRIPTION
…IA labels, CI workflow, Husky hooks

- closes #340: Add LiveRegionProvider with polite/assertive ARIA live regions, wire toasts to announce via screen readers
- closes #333: Add aria-labels to all icon-only buttons (notification bell with dynamic unread count, profile, sidebar close, sort toggles, pagination, search input, toast dismiss)
- closes #339: CI workflow already in place with lint, type-check, test, and build jobs
- closes #341: Husky pre-commit hooks already configured with lint-staged
- Update tests to match new ARIA attributes