### PR TITLE
feat(a11y,testing,dashboard): focus trap hook, utils tests, ui tests, anomaly panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Signup from './pages/auth/Signup/Signup';
 import Login from './pages/auth/Login/Login';
 import ForgotPassword from './pages/auth/ForgotPassword/ForgotPassword';
 import CompanyDashboard from './pages/dashboard/Company/CompanyDashboard';
+import AnomalyAlertPanel from './pages/dashboard/Company/AnomalyPanel/AnomalyAlertPanel';
 import Shipments from './pages/Shipments/Shipments';
 import ShipmentDetail from './pages/ShipmentDetail/ShipmentDetail';
 import BlockchainLedger from './pages/BlockchainLedger/BlockchainLedger';
@@ -56,6 +57,10 @@ const router = createBrowserRouter([
           {
             path: '/dashboard',
             element: <CompanyDashboard />,
+          },
+          {
+            path: '/dashboard/anomalies',
+            element: <AnomalyAlertPanel />,
           },
           {
             path: '/dashboard/shipments',

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import {
   Rocket,
@@ -8,7 +8,9 @@ import {
   BarChart2,
   Settings,
   HelpCircle,
+  AlertTriangle,
 } from "lucide-react";
+import { anomalyApi } from "@services/api/endpoints/anomalies";
 
 export interface SidebarProps {
   isOpen: boolean;
@@ -25,6 +27,15 @@ const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [openAnomalyCount, setOpenAnomalyCount] = useState(0);
+
+  useEffect(() => {
+    anomalyApi.getAll().then((result) => {
+      setOpenAnomalyCount(result.data.filter((a) => !a.resolved).length);
+    }).catch(() => {
+      // non-critical; badge just won't show
+    });
+  }, []);
 
   const mainNav = [
     {
@@ -36,6 +47,12 @@ const Sidebar: React.FC<SidebarProps> = ({
       name: "Shipments",
       icon: <Truck size={22} className="nav-icon-svg" />,
       path: "/dashboard/shipments",
+    },
+    {
+      name: "Anomalies",
+      icon: <AlertTriangle size={22} className="nav-icon-svg" />,
+      path: "/dashboard/anomalies",
+      badge: openAnomalyCount > 0 ? openAnomalyCount : undefined,
     },
     {
       name: "Team",
@@ -86,7 +103,17 @@ const Sidebar: React.FC<SidebarProps> = ({
               }}
               title={item.name}
             >
-              <div className="nav-icon-wrapper">{item.icon}</div>
+              <div className="nav-icon-wrapper" style={{ position: 'relative' }}>
+                {item.icon}
+                {'badge' in item && item.badge !== undefined && (
+                  <span
+                    className="absolute -top-1 -right-1 flex items-center justify-center w-4 h-4 rounded-full bg-[#ef4444] text-white text-[9px] font-bold leading-none"
+                    aria-label={`${item.badge} open anomalies`}
+                  >
+                    {item.badge > 99 ? '99+' : item.badge}
+                  </span>
+                )}
+              </div>
               {!isCollapsed && <span className="nav-label">{item.name}</span>}
             </button>
           );

--- a/frontend/src/components/ui/StatusBadge/StatusBadge.test.tsx
+++ b/frontend/src/components/ui/StatusBadge/StatusBadge.test.tsx
@@ -3,24 +3,15 @@ import { describe, it, expect } from 'vitest';
 import { StatusBadge } from './StatusBadge';
 
 describe('StatusBadge', () => {
+  // --- Rendering ---
   it('renders the display label for a known status', () => {
     render(<StatusBadge status="CREATED" />);
     expect(screen.getByText('Pending Approval')).toBeInTheDocument();
   });
 
-  it('renders all known statuses with correct labels', () => {
-    const statuses = [
-      { status: 'CREATED', label: 'Pending Approval' },
-      { status: 'IN_TRANSIT', label: 'In Transit' },
-      { status: 'DELIVERED', label: 'Delivered' },
-      { status: 'CANCELLED', label: 'Cancelled' },
-    ];
-
-    statuses.forEach(({ status, label }) => {
-      const { unmount } = render(<StatusBadge status={status} />);
-      expect(screen.getByText(label)).toBeInTheDocument();
-      unmount();
-    });
+  it('renders as a span element', () => {
+    render(<StatusBadge status="DELIVERED" />);
+    expect(screen.getByText('Delivered').tagName).toBe('SPAN');
   });
 
   it('falls back to raw status string for unknown statuses', () => {
@@ -28,26 +19,54 @@ describe('StatusBadge', () => {
     expect(screen.getByText('UNKNOWN_STATUS')).toBeInTheDocument();
   });
 
-  it('has an accessible aria-label', () => {
-    render(<StatusBadge status="DELIVERED" />);
-    expect(screen.getByLabelText('Shipment status: Delivered')).toBeInTheDocument();
+  // --- All variants ---
+  it.each([
+    { status: 'CREATED',    label: 'Pending Approval', colorToken: '#f59e0b' },
+    { status: 'IN_TRANSIT', label: 'In Transit',        colorToken: '#3b82f6' },
+    { status: 'DELIVERED',  label: 'Delivered',         colorToken: '#10b981' },
+    { status: 'CANCELLED',  label: 'Cancelled',         colorToken: '#ef4444' },
+  ])('renders $status with correct label and color class', ({ status, label, colorToken }) => {
+    const { unmount } = render(<StatusBadge status={status} />);
+    const badge = screen.getByText(label);
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain(colorToken);
+    unmount();
   });
 
-  it('applies custom className', () => {
+  // --- Accessibility ---
+  it.each([
+    { status: 'CREATED',    ariaLabel: 'Shipment status: Pending Approval' },
+    { status: 'IN_TRANSIT', ariaLabel: 'Shipment status: In Transit'        },
+    { status: 'DELIVERED',  ariaLabel: 'Shipment status: Delivered'         },
+    { status: 'CANCELLED',  ariaLabel: 'Shipment status: Cancelled'         },
+  ])('has correct aria-label for $status', ({ status, ariaLabel }) => {
+    const { unmount } = render(<StatusBadge status={status} />);
+    expect(screen.getByLabelText(ariaLabel)).toBeInTheDocument();
+    unmount();
+  });
+
+  it('aria-label reflects raw value for unknown status', () => {
+    render(<StatusBadge status="PENDING_REVIEW" />);
+    expect(screen.getByLabelText('Shipment status: PENDING_REVIEW')).toBeInTheDocument();
+  });
+
+  // --- className prop ---
+  it('applies a custom className alongside base classes', () => {
     render(<StatusBadge status="CREATED" className="my-custom-class" />);
     const badge = screen.getByText('Pending Approval');
     expect(badge).toHaveClass('my-custom-class');
+    expect(badge).toHaveClass('rounded-full');
   });
 
-  it('renders as a span element', () => {
+  it('works without a custom className', () => {
     render(<StatusBadge status="DELIVERED" />);
-    const badge = screen.getByText('Delivered');
-    expect(badge.tagName).toBe('SPAN');
+    expect(screen.getByText('Delivered')).toBeInTheDocument();
   });
 
-  it('applies status-specific badge classes', () => {
-    render(<StatusBadge status="DELIVERED" />);
-    const badge = screen.getByText('Delivered');
-    expect(badge.className).toContain('text-[#10b981]');
+  // --- Unknown status fallback styling ---
+  it('applies fallback classes for an unknown status', () => {
+    render(<StatusBadge status="UNKNOWN" />);
+    const badge = screen.getByText('UNKNOWN');
+    expect(badge.className).toContain('bg-text-secondary');
   });
 });

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useAuth } from './useAuth';
 export { useKeyboardShortcuts } from './useKeyboardShortcuts';
 export type { ShortcutDef } from './useKeyboardShortcuts';
+export { useFocusTrap } from './useFocusTrap';

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,77 @@
+import { useEffect, useCallback, RefObject } from 'react';
+
+const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Traps keyboard focus inside the given container element while active.
+ *
+ * - On activation: saves the previously-focused element and moves focus to the
+ *   first focusable element inside the container (or the container itself).
+ * - Tab / Shift+Tab: wraps focus at the boundaries of the container.
+ * - Escape: calls onEscape if provided.
+ * - On deactivation: restores focus to the previously-focused element.
+ */
+export function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+  onEscape?: () => void
+): void {
+  const getFocusable = useCallback((): HTMLElement[] => {
+    if (!ref.current) return [];
+    return Array.from(ref.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
+  }, [ref]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onEscape?.();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [getFocusable, onEscape]
+  );
+
+  useEffect(() => {
+    if (!active) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    document.addEventListener('keydown', handleKeyDown);
+
+    const raf = requestAnimationFrame(() => {
+      const focusable = getFocusable();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        ref.current?.focus();
+      }
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [active, handleKeyDown, getFocusable, ref]);
+}
+
+export default useFocusTrap;

--- a/frontend/src/pages/Payments/PaymentDetailModal/PaymentDetailModal.tsx
+++ b/frontend/src/pages/Payments/PaymentDetailModal/PaymentDetailModal.tsx
@@ -1,6 +1,7 @@
 // frontend/src/pages/Payments/PaymentDetailModal/PaymentDetailModal.tsx
-import React, { useEffect } from "react";
+import React, { useRef } from "react";
 import { X, ExternalLink, ShieldCheck, MapPin } from "lucide-react";
+import { useFocusTrap } from "@hooks/useFocusTrap";
 import "./PaymentDetailModal.css";
 
 interface PaymentDetailModalProps {
@@ -24,13 +25,8 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
     onClose,
     payment,
 }) => {
-    useEffect(() => {
-        const handleEsc = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
-        };
-        window.addEventListener("keydown", handleEsc);
-        return () => window.removeEventListener("keydown", handleEsc);
-    }, [onClose]);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(dialogRef, isOpen, onClose);
 
     if (!isOpen || !payment) return null;
 
@@ -57,8 +53,16 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
 
     return (
         <div className="modal-overlay" onClick={onClose}>
-            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-                <button className="close-btn" onClick={onClose}>
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="payment-modal-title"
+                tabIndex={-1}
+                className="modal-content"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <button className="close-btn" onClick={onClose} aria-label="Close modal">
                     <X size={24} />
                 </button>
 
@@ -73,7 +77,7 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
                             ID: #{payment.id.padStart(6, "0")}
                         </span>
                     </div>
-                    <h2 className="payment-amount">
+                    <h2 id="payment-modal-title" className="payment-amount">
                         {payment.amount.toLocaleString()}{" "}
                         <span className="token">{payment.token}</span>
                     </h2>

--- a/frontend/src/pages/Settlements/components/PaymentDetailModal.tsx
+++ b/frontend/src/pages/Settlements/components/PaymentDetailModal.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { Settlement, SettlementDetail } from "@services/api/endpoints/settlements";
+import { useFocusTrap } from "@hooks/useFocusTrap";
 
 interface PaymentDetailModalProps {
     isOpen: boolean;
@@ -28,6 +29,9 @@ export default function PaymentDetailModal({
     detail,
     isLoading,
 }: PaymentDetailModalProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(dialogRef, isOpen, onClose);
+
     useEffect(() => {
         const handleEsc = (e: KeyboardEvent) => {
             if (e.key === "Escape") onClose();
@@ -54,11 +58,16 @@ export default function PaymentDetailModal({
             onClick={onClose}
         >
             <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="settlement-modal-title"
+                tabIndex={-1}
                 className="bg-[rgba(8,40,50,0.95)] border border-[rgba(98,255,255,0.2)] rounded-2xl p-6 w-full max-w-md shadow-xl"
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-lg font-bold text-[#62ffff]">Escrow Details</h2>
+                    <h2 id="settlement-modal-title" className="text-lg font-bold text-[#62ffff]">Escrow Details</h2>
                     <button
                         onClick={onClose}
                         className="text-text-secondary hover:text-white transition-colors"

--- a/frontend/src/pages/dashboard/Company/AnomalyPanel/AnomalyAlertPanel.tsx
+++ b/frontend/src/pages/dashboard/Company/AnomalyPanel/AnomalyAlertPanel.tsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { AlertTriangle, ExternalLink, CheckCircle2, RefreshCw } from 'lucide-react';
+import { anomalyApi, Anomaly, AnomalySeverity } from '@services/api/endpoints/anomalies';
+import { safeFormatDate } from '@utils/safeFormat';
+import { Link } from 'react-router-dom';
+
+const SEVERITY_ORDER: Record<AnomalySeverity, number> = { HIGH: 0, MEDIUM: 1, LOW: 2 };
+
+const SEVERITY_CLASSES: Record<AnomalySeverity, string> = {
+  HIGH:   'bg-[rgba(239,68,68,0.1)]   text-[#ef4444]  border border-[rgba(239,68,68,0.2)]',
+  MEDIUM: 'bg-[rgba(245,158,11,0.1)]  text-[#f59e0b]  border border-[rgba(245,158,11,0.2)]',
+  LOW:    'bg-[rgba(59,130,246,0.1)]  text-[#3b82f6]  border border-[rgba(59,130,246,0.2)]',
+};
+
+const ANOMALY_TYPE_LABELS: Record<string, string> = {
+  TEMPERATURE_EXCEEDED:  'Temperature Exceeded',
+  TEMPERATURE_BELOW_MIN: 'Temperature Below Min',
+  HUMIDITY_EXCEEDED:     'Humidity Exceeded',
+  HUMIDITY_BELOW_MIN:    'Humidity Below Min',
+  BATTERY_LOW:           'Battery Low',
+};
+
+export interface AnomalyAlertPanelProps {}
+
+const AnomalyAlertPanel: React.FC<AnomalyAlertPanelProps> = () => {
+  const [anomalies, setAnomalies] = useState<Anomaly[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [acknowledging, setAcknowledging] = useState<string | null>(null);
+
+  const fetchAnomalies = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await anomalyApi.getAll();
+      const open = result.data
+        .filter((a) => !a.resolved)
+        .sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+      setAnomalies(open);
+    } catch {
+      setError('Failed to load anomalies. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAnomalies();
+  }, [fetchAnomalies]);
+
+  const handleAcknowledge = async (id: string) => {
+    try {
+      setAcknowledging(id);
+      await anomalyApi.resolve(id);
+      setAnomalies((prev) => prev.filter((a) => a._id !== id));
+    } catch {
+      // keep the item in the list; surface no crash
+    } finally {
+      setAcknowledging(null);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-[1080px] mx-auto px-[46px] py-6 flex flex-col gap-6 max-md:px-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-white mb-1">
+            Anomaly Alerts
+          </h1>
+          <p className="text-[#94a3b8] text-sm">
+            Active anomalies sorted by severity — acknowledge to triage
+          </p>
+        </div>
+        <button
+          onClick={fetchAnomalies}
+          disabled={loading}
+          className="flex items-center gap-2 text-sm text-[#94a3b8] hover:text-white transition-colors disabled:opacity-50"
+          aria-label="Refresh anomalies"
+        >
+          <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Count badge */}
+      {!loading && !error && (
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-[#94a3b8]">
+            {anomalies.length === 0
+              ? 'No open anomalies'
+              : `${anomalies.length} open anomal${anomalies.length === 1 ? 'y' : 'ies'}`}
+          </span>
+          {anomalies.length > 0 && (
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#ef4444] text-white text-[11px] font-bold">
+              {anomalies.length}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading && (
+        <div className="flex flex-col gap-3" aria-label="Loading anomalies">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 rounded-xl bg-[#14171e] animate-pulse" />
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {!loading && error && (
+        <div className="flex flex-col items-center justify-center p-12 bg-[#14171e] border border-dashed border-[#ef4444] rounded-xl text-center">
+          <AlertTriangle size={40} className="text-[#ef4444] mb-3" />
+          <p className="text-[#94a3b8] text-sm mb-4">{error}</p>
+          <button
+            onClick={fetchAnomalies}
+            className="bg-[#ef4444] text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-[#dc2626] transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && anomalies.length === 0 && (
+        <div className="flex flex-col items-center justify-center p-12 bg-[#14171e] border border-dashed border-[#1e293b] rounded-xl text-center">
+          <CheckCircle2 size={40} className="text-[#10b981] mb-3" />
+          <p className="text-white font-semibold mb-1">All clear!</p>
+          <p className="text-[#94a3b8] text-sm">No open anomalies at this time.</p>
+        </div>
+      )}
+
+      {/* Anomaly list */}
+      {!loading && !error && anomalies.length > 0 && (
+        <div className="flex flex-col gap-3" role="list" aria-label="Anomaly alerts">
+          {anomalies.map((anomaly) => (
+            <div
+              key={anomaly._id}
+              role="listitem"
+              className="bg-[#14171e] border border-[#1e293b] rounded-xl p-5 flex items-start gap-4 hover:border-[#334155] transition-colors max-md:flex-col"
+            >
+              {/* Icon */}
+              <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-[rgba(239,68,68,0.08)] flex items-center justify-center mt-0.5">
+                <AlertTriangle size={18} className="text-[#ef4444]" />
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap mb-1">
+                  <span
+                    className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide ${SEVERITY_CLASSES[anomaly.severity]}`}
+                    aria-label={`Severity: ${anomaly.severity}`}
+                  >
+                    {anomaly.severity}
+                  </span>
+                  <span className="text-white font-medium text-sm">
+                    {ANOMALY_TYPE_LABELS[anomaly.type] ?? anomaly.type}
+                  </span>
+                </div>
+
+                <p className="text-[#94a3b8] text-sm leading-relaxed mb-2 line-clamp-2">
+                  {anomaly.message}
+                </p>
+
+                <div className="flex items-center gap-4 text-xs text-[#64748b]">
+                  <span>Detected: {safeFormatDate(anomaly.timestamp)}</span>
+                  <span className="truncate max-w-[200px]">
+                    Shipment:{' '}
+                    <span className="text-[#94a3b8] font-mono">{anomaly.shipmentId}</span>
+                  </span>
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-2 flex-shrink-0 max-md:w-full max-md:justify-end">
+                <Link
+                  to={`/dashboard/shipments/${anomaly.shipmentId}`}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[#1e293b] text-[#94a3b8] text-xs font-medium hover:border-[#334155] hover:text-white transition-colors"
+                  aria-label={`View shipment ${anomaly.shipmentId}`}
+                >
+                  <ExternalLink size={13} />
+                  View Shipment
+                </Link>
+                <button
+                  onClick={() => handleAcknowledge(anomaly._id)}
+                  disabled={acknowledging === anomaly._id}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-[rgba(16,185,129,0.1)] border border-[rgba(16,185,129,0.2)] text-[#10b981] text-xs font-medium hover:bg-[rgba(16,185,129,0.2)] transition-colors disabled:opacity-50"
+                  aria-label={`Acknowledge anomaly ${anomaly._id}`}
+                >
+                  <CheckCircle2 size={13} />
+                  {acknowledging === anomaly._id ? 'Acknowledging…' : 'Acknowledge'}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AnomalyAlertPanel;

--- a/frontend/src/pages/dashboard/Company/UserManagement/UserManagement.tsx
+++ b/frontend/src/pages/dashboard/Company/UserManagement/UserManagement.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { Search, Filter, Plus, ChevronLeft, ChevronRight, MoreVertical, X, Loader2, AlertTriangle } from 'lucide-react';
 import { usersApi } from '@services/api';
 import type { User as ApiUser, UserRole } from '@services/api';
 import { useToast } from '../../../../context/ToastContext';
+import { useFocusTrap } from '../../../../hooks/useFocusTrap';
 import './UserManagement.css';
 
 interface MappedUser {
@@ -38,6 +39,9 @@ const UserManagement: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const inviteModalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(inviteModalRef, isModalOpen, () => setIsModalOpen(false));
 
   // Modal Form State
   const [inviteEmail, setInviteEmail] = useState('');
@@ -303,9 +307,16 @@ const UserManagement: React.FC = () => {
 
       {isModalOpen && (
         <div className="modal-overlay">
-          <div className="invite-modal">
+          <div
+            ref={inviteModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="invite-modal-title"
+            tabIndex={-1}
+            className="invite-modal"
+          >
             <div className="modal-header">
-              <h2>Invite New User</h2>
+              <h2 id="invite-modal-title">Invite New User</h2>
               <button className="close-btn" onClick={() => setIsModalOpen(false)}>
                 <X size={20} />
               </button>

--- a/frontend/src/utils/shipmentStatus.test.ts
+++ b/frontend/src/utils/shipmentStatus.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { getStatusDisplayLabel, getStatusBadgeClass, getStatusDotClass } from './shipmentStatus';
+
+// ---------------------------------------------------------------------------
+// getStatusDisplayLabel
+// ---------------------------------------------------------------------------
+
+describe('getStatusDisplayLabel', () => {
+  it('returns correct display labels for all known statuses', () => {
+    expect(getStatusDisplayLabel('CREATED')).toBe('Pending Approval');
+    expect(getStatusDisplayLabel('IN_TRANSIT')).toBe('In Transit');
+    expect(getStatusDisplayLabel('DELIVERED')).toBe('Delivered');
+    expect(getStatusDisplayLabel('CANCELLED')).toBe('Cancelled');
+  });
+
+  it("returns 'Unknown' for empty string", () => {
+    expect(getStatusDisplayLabel('')).toBe('Unknown');
+  });
+
+  it("returns 'Unknown' for null", () => {
+    // @ts-expect-error testing runtime behaviour
+    expect(getStatusDisplayLabel(null)).toBe('Unknown');
+  });
+
+  it("returns 'Unknown' for undefined", () => {
+    // @ts-expect-error testing runtime behaviour
+    expect(getStatusDisplayLabel(undefined)).toBe('Unknown');
+  });
+
+  it('returns the raw string for an unknown status', () => {
+    expect(getStatusDisplayLabel('SOME_OTHER_STATUS')).toBe('SOME_OTHER_STATUS');
+  });
+
+  it('is case-sensitive — lowercase input returns raw string', () => {
+    expect(getStatusDisplayLabel('created')).toBe('created');
+    expect(getStatusDisplayLabel('delivered')).toBe('delivered');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStatusBadgeClass
+// ---------------------------------------------------------------------------
+
+describe('getStatusBadgeClass', () => {
+  it('returns CREATED badge class with amber color token', () => {
+    expect(getStatusBadgeClass('CREATED')).toContain('#f59e0b');
+  });
+
+  it('returns IN_TRANSIT badge class with blue color token', () => {
+    expect(getStatusBadgeClass('IN_TRANSIT')).toContain('#3b82f6');
+  });
+
+  it('returns DELIVERED badge class with green color token', () => {
+    expect(getStatusBadgeClass('DELIVERED')).toContain('#10b981');
+  });
+
+  it('returns CANCELLED badge class with red color token', () => {
+    expect(getStatusBadgeClass('CANCELLED')).toContain('#ef4444');
+  });
+
+  it('returns a fallback class for an unknown status', () => {
+    expect(getStatusBadgeClass('UNKNOWN_STATUS')).toContain('bg-text-secondary/10');
+  });
+
+  it('returns a fallback class for empty string', () => {
+    expect(getStatusBadgeClass('')).toContain('bg-text-secondary/10');
+  });
+
+  it('returns a string for every known status (no crashes)', () => {
+    ['CREATED', 'IN_TRANSIT', 'DELIVERED', 'CANCELLED'].forEach((s) => {
+      expect(typeof getStatusBadgeClass(s)).toBe('string');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStatusDotClass
+// ---------------------------------------------------------------------------
+
+describe('getStatusDotClass', () => {
+  it('returns dot class for CREATED', () => {
+    expect(getStatusDotClass('CREATED')).toContain('#f59e0b');
+  });
+
+  it('returns dot class for IN_TRANSIT', () => {
+    expect(getStatusDotClass('IN_TRANSIT')).toContain('#3b82f6');
+  });
+
+  it('returns dot class for DELIVERED', () => {
+    expect(getStatusDotClass('DELIVERED')).toContain('#10b981');
+  });
+
+  it('returns dot class for CANCELLED', () => {
+    expect(getStatusDotClass('CANCELLED')).toContain('#ef4444');
+  });
+
+  it('returns fallback class for unknown status', () => {
+    expect(getStatusDotClass('UNKNOWN_STATUS')).toBe('bg-text-secondary');
+  });
+
+  it('returns fallback class for empty string', () => {
+    expect(getStatusDotClass('')).toBe('bg-text-secondary');
+  });
+});


### PR DESCRIPTION
## Summary

Implements four assigned issues in a single cohesive PR. All changes are additive or minimal surgical edits to existing files; pre-existing build errors (Soroban SDK, Analytics types, Sentry ErrorFallback) are untouched per contribution guidelines.

---

## Issues Closed

Closes #337
Closes #336
Closes #335
Closes #305

---

## Changes

### #337 — [A11y] Add Focus Trap in All Modal and Dialog Components

- **New:** `frontend/src/hooks/useFocusTrap.ts`
  - Accepts a `ref` + `active` flag + optional `onEscape` callback
  - On activation: saves previously-focused element, moves focus to first focusable child
  - Tab / Shift+Tab wraps at first/last focusable boundary
  - Escape calls `onEscape`; on deactivation restores prior focus
- Exported from `hooks/index.ts`
- Applied to `PaymentDetailModal` (Payments), `PaymentDetailModal` (Settlements), and `UserManagement` invite modal — each now has `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, `tabIndex=-1`

### #335 — Unit Tests for All Utility Functions in /src/utils

- **New:** `frontend/src/utils/shipmentStatus.test.ts` — co-located tests for `getStatusDisplayLabel`, `getStatusBadgeClass`, `getStatusDotClass` covering all known statuses, empty string, null, undefined, unknown fallback, and case-sensitivity

### #336 — Component Tests for All UI Components in /components/ui

- **Updated:** `frontend/src/components/ui/StatusBadge/StatusBadge.test.tsx` — `it.each` for all 4 status variants (label + color token + aria-label), unknown-status fallback, className merging, element type

### #305 — Anomaly Alert Management Panel

- **New:** `frontend/src/pages/dashboard/Company/AnomalyPanel/AnomalyAlertPanel.tsx`
  - Fetches open anomalies, sorts HIGH → MEDIUM → LOW, severity badges, Acknowledge + View Shipment actions
  - Loading/error/empty states; open-count badge
- **Route** `/dashboard/anomalies` registered in `App.tsx`
- **Sidebar** Anomalies nav item added with live count badge

---

## Testing / Validation

- `pnpm test` — **257 / 257 tests pass** (27 test files)
- `pnpm lint` — 0 errors, 0 warnings in new/modified files
- Build type errors are **all pre-existing** on `main` (confirmed by stash comparison before changes)

---

## Notes for Reviewers

- `anomalyApi.resolve()` is used for Acknowledge (the only PATCH endpoint in the existing service layer — maps to `/anomalies/:id/resolve`).
- `DisputeForm`, `WalletModal`, and QR code modal mentioned in #337 do not yet exist in the codebase; the three modals that exist are covered.
- The base `Modal` component already had focus trap built-in; `useFocusTrap` extracts that logic for reuse across all custom modal implementations.