### PR TITLE
feat(auth/a11y): session timeout warning modal and ARIA labels on ico…

### DIFF
--- a/frontend/src/components/auth/SessionTimeoutModal/SessionTimeoutModal.tsx
+++ b/frontend/src/components/auth/SessionTimeoutModal/SessionTimeoutModal.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Modal from '../../common/Modal/Modal';
+import { useToast } from '../../../context/ToastContext';
+import { authApi } from '../../../services/api/endpoints/auth';
+
+/** Minutes before expiry to show the warning modal. */
+const WARN_BEFORE_MS = 2 * 60 * 1000; // 2 minutes
+
+function getTokenExpiry(): number | null {
+  const token = localStorage.getItem('authToken');
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return typeof payload.exp === 'number' ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SessionTimeoutModalProps {
+  /** Called after a successful token refresh or sign-out, so the parent can
+   *  re-schedule the next check. Leave undefined to use the built-in logic. */
+  onSessionExtended?: () => void;
+}
+
+const SessionTimeoutModal: React.FC<SessionTimeoutModalProps> = ({ onSessionExtended }) => {
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [countdown, setCountdown] = useState(WARN_BEFORE_MS / 1000);
+
+  // Refs keep mutable values accessible inside setInterval without stale closures
+  const warnTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const expireTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearTimers = () => {
+    if (warnTimerRef.current) clearTimeout(warnTimerRef.current);
+    if (expireTimerRef.current) clearTimeout(expireTimerRef.current);
+    if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
+  };
+
+  const performLogout = (expired: boolean) => {
+    clearTimers();
+    setIsOpen(false);
+    localStorage.removeItem('authToken');
+    if (expired) {
+      addToast('Your session has expired. Please sign in again.', 'error');
+    }
+    navigate('/login', { replace: true });
+  };
+
+  const schedule = () => {
+    clearTimers();
+    const expiry = getTokenExpiry();
+    if (!expiry) return;
+
+    const now = Date.now();
+    const msUntilWarn = expiry - now - WARN_BEFORE_MS;
+    const msUntilExpire = expiry - now;
+
+    if (msUntilExpire <= 0) {
+      performLogout(true);
+      return;
+    }
+
+    if (msUntilWarn > 0) {
+      warnTimerRef.current = setTimeout(() => {
+        setIsOpen(true);
+        setCountdown(Math.round(WARN_BEFORE_MS / 1000));
+        countdownIntervalRef.current = setInterval(() => {
+          setCountdown((prev) => Math.max(0, prev - 1));
+        }, 1000);
+      }, msUntilWarn);
+    } else {
+      // Less than 2 min remaining on mount — show immediately
+      setIsOpen(true);
+      const remaining = Math.max(0, Math.round(msUntilExpire / 1000));
+      setCountdown(remaining);
+      countdownIntervalRef.current = setInterval(() => {
+        setCountdown((prev) => Math.max(0, prev - 1));
+      }, 1000);
+    }
+
+    expireTimerRef.current = setTimeout(() => {
+      performLogout(true);
+    }, msUntilExpire);
+  };
+
+  // Initial schedule on mount
+  useEffect(() => {
+    schedule();
+    return clearTimers;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const formatCountdown = (seconds: number): string => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return m > 0 ? `${m}m ${s}s` : `${s}s`;
+  };
+
+  const handleStaySignedIn = async () => {
+    try {
+      await authApi.refresh();
+      clearTimers();
+      setIsOpen(false);
+      schedule();
+      onSessionExtended?.();
+    } catch {
+      // If refresh fails, log the user out cleanly
+      performLogout(false);
+    }
+  };
+
+  const handleSignOut = () => {
+    void authApi.logout().catch(() => {
+      // Ignore logout API errors — we clear local state regardless
+    });
+    performLogout(false);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => undefined} // deliberate no-op: user must choose an action
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+      title="Session Expiring Soon"
+      size="sm"
+      footer={
+        <>
+          <button
+            onClick={handleSignOut}
+            className="px-4 py-2 rounded-lg border border-border text-text-secondary text-sm font-medium hover:bg-background-elevated transition-colors"
+          >
+            Sign Out
+          </button>
+          <button
+            onClick={() => void handleStaySignedIn()}
+            className="px-4 py-2 rounded-lg bg-teal-600 hover:bg-teal-700 text-white text-sm font-semibold transition-colors"
+          >
+            Stay Signed In
+          </button>
+        </>
+      }
+    >
+      <p>
+        Your session will expire in{' '}
+        <span className="font-semibold text-text-primary" aria-live="polite" aria-atomic="true">
+          {formatCountdown(countdown)}
+        </span>
+        . Do you want to stay signed in?
+      </p>
+    </Modal>
+  );
+};
+
+export default SessionTimeoutModal;

--- a/frontend/src/components/auth/SessionTimeoutModal/index.ts
+++ b/frontend/src/components/auth/SessionTimeoutModal/index.ts
@@ -1,0 +1,2 @@
+export { default as SessionTimeoutModal } from './SessionTimeoutModal';
+export type { SessionTimeoutModalProps } from './SessionTimeoutModal';

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import TopHeader from './TopHeader/TopHeader';
 import AnimatedPage from './AnimatedPage';
+import { SessionTimeoutModal } from '../auth/SessionTimeoutModal';
 
 const DashboardLayout: React.FC = () => {
   const navigate = useNavigate();
@@ -145,6 +146,8 @@ const DashboardLayout: React.FC = () => {
           </AnimatedPage>
         </main>
       </div>
+
+      <SessionTimeoutModal />
     </div>
   );
 };

--- a/frontend/src/pages/Notifications/NotificationsPage.tsx
+++ b/frontend/src/pages/Notifications/NotificationsPage.tsx
@@ -184,10 +184,14 @@ const NotificationsPage = () => {
             ))}
           </nav>
           <div className="flex gap-3">
-            {[{ icon: <Bell size={20} />, active: true }, { icon: <Settings size={20} /> }, { icon: <UserCircle size={20} /> }].map(({ icon, active }, i) => (
-              <div key={i} className={`w-10 h-10 rounded-lg flex items-center justify-center cursor-pointer transition-colors ${active ? "bg-[#2563eb] text-white" : "bg-[#1f2937] text-[#9ca3af] hover:bg-[#374151]"}`}>
+            {[
+              { icon: <Bell size={20} />, active: true, label: "Notifications" },
+              { icon: <Settings size={20} />, label: "Settings" },
+              { icon: <UserCircle size={20} />, label: "Profile" },
+            ].map(({ icon, active, label }, i) => (
+              <button key={i} aria-label={label} className={`w-10 h-10 rounded-lg flex items-center justify-center cursor-pointer transition-colors border-none ${active ? "bg-[#2563eb] text-white" : "bg-[#1f2937] text-[#9ca3af] hover:bg-[#374151]"}`}>
                 {icon}
-              </div>
+              </button>
             ))}
           </div>
         </div>

--- a/frontend/src/pages/ShipmentDetail/ShipmentDetailHeader/ShipmentDetailHeader.tsx
+++ b/frontend/src/pages/ShipmentDetail/ShipmentDetailHeader/ShipmentDetailHeader.tsx
@@ -85,6 +85,7 @@ const ShipmentDetailHeader: React.FC<ShipmentDetailHeaderProps> = ({
         {userRole === "customer" && (
           <button
             onClick={onTrack}
+            aria-label="Track shipment"
             className="px-6 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-semibold transition-colors duration-200 w-10 md:w-auto"
           >
             Track

--- a/frontend/src/services/api/endpoints/auth.ts
+++ b/frontend/src/services/api/endpoints/auth.ts
@@ -47,4 +47,9 @@ export const authApi = {
         localStorage.removeItem("authToken");
         Sentry.setUser(null);
     },
+
+    refresh: async (): Promise<void> => {
+        const res = await apiClient.post<{ data: { token: string } }>("/auth/refresh");
+        localStorage.setItem("authToken", res.data.data.token);
+    },
 };


### PR DESCRIPTION
…n buttons

#325 - Session Timeout Warning Modal
- Add SessionTimeoutModal component that reads JWT exp claim from localStorage and triggers a warning 2 minutes before expiry
- Countdown ticks live in the modal with aria-live for screen readers
- 'Stay Signed In' calls POST /api/auth/refresh and reschedules the timer
- 'Sign Out' clears the token and redirects to /login
- Auto-logout on expiry shows an error toast before redirecting
- Mount SessionTimeoutModal in DashboardLayout (authenticated layout)
- Add authApi.refresh() to auth endpoint service

#327 - ARIA Labels on Icon-Only Buttons
- NotificationsPage: convert header icon divs to <button> elements and add aria-label (Notifications, Settings, Profile)
- ShipmentDetailHeader: add aria-label='Track shipment' to Track button
closes #325 
closes #327 