### PR TITLE
fix: resolve issues #202, #203, #204, #205

### DIFF
--- a/frontend/src/pages/ShipmentDetail/EscrowStatus/EscrowStatus.tsx
+++ b/frontend/src/pages/ShipmentDetail/EscrowStatus/EscrowStatus.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from "react";
+import { ExternalLink, ShieldCheck, Loader2 } from "lucide-react";
+import {
+    settlementsApi,
+    Settlement,
+    SettlementStatus,
+} from "@services/api/endpoints/settlements";
+
+export interface EscrowStatusProps {
+    shipmentId: string;
+}
+
+const STATUS_STYLES: Record<SettlementStatus, string> = {
+    PENDING:
+        "bg-yellow-500/20 text-yellow-300 border border-yellow-500/40",
+    ESCROWED:
+        "bg-blue-500/20 text-blue-300 border border-blue-500/40",
+    RELEASED:
+        "bg-green-500/20 text-green-300 border border-green-500/40",
+    DISPUTED:
+        "bg-red-500/20 text-red-300 border border-red-500/40",
+    FAILED:
+        "bg-red-500/20 text-red-300 border border-red-500/40",
+};
+
+const truncateHash = (hash: string) =>
+    hash.length <= 12 ? hash : `${hash.slice(0, 6)}...${hash.slice(-4)}`;
+
+const getStellarExplorerUrl = (hash: string) =>
+    `https://stellar.expert/explorer/testnet/tx/${hash}`;
+
+const EscrowStatus: React.FC<EscrowStatusProps> = ({ shipmentId }) => {
+    const [settlements, setSettlements] = useState<Settlement[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!shipmentId) return;
+        settlementsApi
+            .getByShipmentId(shipmentId)
+            .then(setSettlements)
+            .catch(() => setError("Failed to load escrow records."))
+            .finally(() => setLoading(false));
+    }, [shipmentId]);
+
+    return (
+        <div className="bg-[rgba(8,40,50,0.4)] border-[1.5px] border-[rgba(0,180,160,0.3)] rounded-3xl px-8 py-12 backdrop-blur-md shadow-[0_8px_32px_rgba(0,0,0,0.3)] mt-8 md:px-5 md:py-8 md:rounded-2xl sm:px-4 sm:py-6">
+            <h2 className="font-['Bebas_Neue',sans-serif] text-[clamp(1.75rem,4vw,2.5rem)] font-normal tracking-[0.04em] leading-[1.2] text-white text-center mb-8">
+                ESCROW <span className="text-[#00d4c8]">STATUS</span>
+            </h2>
+
+            {loading && (
+                <div className="flex items-center justify-center gap-3 py-10 text-[rgba(255,255,255,0.5)]">
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                    <span>Loading escrow records…</span>
+                </div>
+            )}
+
+            {!loading && error && (
+                <p className="text-center text-red-400 py-8">{error}</p>
+            )}
+
+            {!loading && !error && settlements.length === 0 && (
+                <div className="bg-[rgba(0,0,0,0.2)] rounded-2xl border border-[rgba(255,255,255,0.05)] px-8 py-12 flex flex-col items-center text-center">
+                    <div className="bg-[rgba(255,255,255,0.05)] rounded-full w-20 h-20 flex items-center justify-center mb-6">
+                        <ShieldCheck className="w-10 h-10 text-[rgba(255,255,255,0.3)]" />
+                    </div>
+                    <h3 className="text-white text-xl font-semibold m-0 mb-2">
+                        No Escrow Records
+                    </h3>
+                    <p className="text-[rgba(255,255,255,0.5)] text-base m-0 max-w-md">
+                        No settlement records found for this shipment yet.
+                    </p>
+                </div>
+            )}
+
+            {!loading && !error && settlements.length > 0 && (
+                <div className="flex flex-col gap-4">
+                    {settlements.map((s) => (
+                        <div
+                            key={s._id}
+                            className="bg-[rgba(0,0,0,0.2)] rounded-2xl border border-[rgba(255,255,255,0.05)] px-6 py-5 flex flex-col gap-3"
+                        >
+                            {/* Status + amount row */}
+                            <div className="flex items-center justify-between flex-wrap gap-3">
+                                <span className="text-white font-semibold text-lg">
+                                    {s.amount}{" "}
+                                    <span className="text-[#00d4c8]">{s.token}</span>
+                                </span>
+                                <span
+                                    className={`inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-semibold ${STATUS_STYLES[s.status]}`}
+                                >
+                                    <span
+                                        className={`w-2 h-2 rounded-full ${
+                                            s.status === "RELEASED"
+                                                ? "bg-green-400"
+                                                : s.status === "ESCROWED"
+                                                ? "bg-blue-400 animate-pulse"
+                                                : s.status === "PENDING"
+                                                ? "bg-yellow-400 animate-pulse"
+                                                : "bg-red-400"
+                                        }`}
+                                    />
+                                    {s.status}
+                                </span>
+                            </div>
+
+                            {/* Transaction hash */}
+                            {s.stellarTxHash && (
+                                <div className="flex items-center gap-2 text-sm">
+                                    <span className="text-[rgba(255,255,255,0.5)]">
+                                        Tx Hash:
+                                    </span>
+                                    <a
+                                        href={getStellarExplorerUrl(s.stellarTxHash)}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1.5 text-[#00d4c8] font-mono hover:text-[#1fffff] transition-colors"
+                                        title={s.stellarTxHash}
+                                    >
+                                        {truncateHash(s.stellarTxHash)}
+                                        <ExternalLink className="w-3.5 h-3.5 opacity-70" />
+                                    </a>
+                                </div>
+                            )}
+
+                            {/* Escrow release info */}
+                            {s.escrowRelease?.releasedAt && (
+                                <p className="text-xs text-[rgba(255,255,255,0.4)]">
+                                    Released:{" "}
+                                    {new Date(s.escrowRelease.releasedAt).toLocaleString()}
+                                </p>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default EscrowStatus;

--- a/frontend/src/pages/ShipmentDetail/ShipmentDetail.tsx
+++ b/frontend/src/pages/ShipmentDetail/ShipmentDetail.tsx
@@ -9,6 +9,7 @@ import DeliveryProofUpload from "./DeliveryProofUpload/DeliveryProofUpload";
 import DeliveryConfirmation from "../../components/shipment/DeliveryConfirmation/DeliveryConfirmation";
 import PaymentStatus, { PaymentData } from "./PaymentStatus/PaymentStatus";
 import SensorDataCards, { SensorData } from "./SensorDataCards/SensorDataCards";
+import EscrowStatus from "./EscrowStatus/EscrowStatus";
 
 const ShipmentDetail: React.FC = () => {
     const { id } = useParams<{ id: string }>();
@@ -199,6 +200,7 @@ const ShipmentDetail: React.FC = () => {
 
                 <SensorDataCards sensorData={mockSensorData} />
                 <PaymentStatus payment={mockPaymentData} />
+                <EscrowStatus shipmentId={id ?? shipmentHeaderData.shipmentId} />
                 <DeliveryProofUpload shipmentId={id || shipmentHeaderData.shipmentId} />
                 <DeliveryConfirmation
                     shipmentId={shipmentHeaderData.shipmentId}

--- a/frontend/src/pages/ShipmentDetail/index.ts
+++ b/frontend/src/pages/ShipmentDetail/index.ts
@@ -1,3 +1,5 @@
 export { default } from './ShipmentDetail';
 export { default as MilestoneTimeline } from './MilestoneTimeline/MilestoneTimeline';
 export type { MilestoneDetail, MilestoneTimelineProps } from './MilestoneTimeline/MilestoneTimeline';
+export { default as EscrowStatus } from './EscrowStatus/EscrowStatus';
+export type { EscrowStatusProps } from './EscrowStatus/EscrowStatus';

--- a/frontend/src/pages/dashboard/Company/CreateShipment/CreateShipment.tsx
+++ b/frontend/src/pages/dashboard/Company/CreateShipment/CreateShipment.tsx
@@ -88,7 +88,7 @@ const CreateShipment: React.FC = () => {
             };
 
             const shipment = await shipmentApi.create(payload);
-            setShipmentId(shipment._id);
+            setShipmentId(shipment.id ?? shipment._id);
             setSuccess(true);
             addToast('Shipment created successfully!', 'success');
         } catch (err) {

--- a/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.tsx
+++ b/frontend/src/pages/dashboard/Company/RecentShipments/RecentShipments.tsx
@@ -126,8 +126,8 @@ const RecentShipments: React.FC<RecentShipmentsProps> = ({ shipments }) => {
         </thead>
         <tbody>
           {currentRows.map(shipment => (
-            <tr key={shipment._id} className="hover:bg-[rgba(255,255,255,0.02)] transition-colors">
-              <td className={`${tdBase} font-medium text-text-primary`}>{shipment._id}</td>
+            <tr key={shipment.id ?? shipment._id} className="hover:bg-[rgba(255,255,255,0.02)] transition-colors">
+              <td className={`${tdBase} font-medium text-text-primary`}>{shipment.id ?? shipment._id}</td>
               <td className={tdBase}>{shipment.origin}</td>
               <td className={tdBase}>{shipment.destination}</td>
               <td className={tdBase}>

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -20,5 +20,28 @@ apiClient.interceptors.request.use((config) => {
     return config;
 });
 
+/**
+ * #202: Recursively map _id → id so frontend code can use the canonical `id`
+ * field regardless of whether MongoDB returns `_id`.
+ */
+const mapIdFields = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(mapIdFields);
+    if (value !== null && typeof value === "object") {
+        const obj = value as Record<string, unknown>;
+        if ("_id" in obj && !("id" in obj)) {
+            obj.id = obj._id;
+        }
+        for (const key of Object.keys(obj)) {
+            obj[key] = mapIdFields(obj[key]);
+        }
+    }
+    return value;
+};
+
+apiClient.interceptors.response.use((response) => {
+    response.data = mapIdFields(response.data);
+    return response;
+});
+
 setupAuthInterceptor(apiClient);
 setupErrorInterceptor(apiClient);

--- a/frontend/src/services/api/endpoints/settlements.ts
+++ b/frontend/src/services/api/endpoints/settlements.ts
@@ -96,5 +96,13 @@ export const settlementsApi = {
         );
         return res.data.data;
     },
+
+    getByShipmentId: async (shipmentId: string): Promise<Settlement[]> => {
+        const res = await apiClient.get<{ data: PaginatedSettlements }>(
+            "/settlements",
+            { params: { shipmentId } },
+        );
+        return res.data.data.data;
+    },
 };
 

--- a/frontend/src/services/api/endpoints/shipments.ts
+++ b/frontend/src/services/api/endpoints/shipments.ts
@@ -10,6 +10,8 @@ export interface ShipmentMilestone {
 
 export interface Shipment {
     _id: string;
+    /** Normalized from _id by the apiClient response interceptor (#202). Available on all responses. */
+    id?: string;
     trackingNumber: string;
     origin: string;
     destination: string;


### PR DESCRIPTION
i Added a response interceptor in `services/api/client.ts` that recursively walks every API response and copies `_id` → `id` on any object that has `_id` but not `id`. This is a single, centralised fix that covers all endpoints (shipments, anomalies, settlements, users) without touching each endpoint file.
- Added the optional `id?: string` field to the `Shipment` interface in `services/api/endpoints/shipments.ts` so TypeScript knows the field exists after the interceptor runs. Kept it optional (`id?`) so existing test fixtures that only supply `_id` do not need to change.
- Updated `RecentShipments.tsx` to use `shipment.id ?? shipment._id` as the row key and displayed Shipment ID column value, ensuring both interceptor- enriched runtime data and raw test fixtures work correctly.

Files changed: `services/api/client.ts`, `services/api/endpoints/shipments.ts`, `pages/dashboard/Company/RecentShipments/RecentShipments.tsx`

---

## Issue #203 — Align /anomalies envelope parsing



i Audited `services/api/endpoints/anomalies.ts`: `anomalyApi.getAll()` already reads `res.data.data` for the array and `res.data.meta` for pagination, which matches the backend envelope `{ data: Anomaly[], meta: { nextCursor, hasMore } }`. The `AnomalyAlertPanel` component correctly uses `result.data` after the call. No change was needed.

---

## Issue #204 — Make CreateShipment tolerate optional trackingNumber

i Changed `setShipmentId(shipment._id)` → `setShipmentId(shipment.id ?? shipment._id)` in the `handleSubmit` success handler so the displayed Shipment ID in the success view is always populated regardless of whether the interceptor has run.
- `trackingNumber` was already absent from the `CreateShipmentRequest` payload sent by `handleSubmit` (confirmed by audit). The field is typed as optional (`trackingNumber?: string`) in `CreateShipmentRequest`, so the backend can generate it when absent. No payload change needed.

Files changed: `pages/dashboard/Company/CreateShipment/CreateShipment.tsx`

---

## Issue #205 — Show settlement/escrow status on ShipmentDetail

i  Added `settlementsApi.getByShipmentId(shipmentId)` to `services/api/endpoints/settlements.ts`. It calls `GET /settlements?shipmentId=...` and returns the `Settlement[]` array for that specific shipment.
- Created `pages/ShipmentDetail/EscrowStatus/EscrowStatus.tsx` — a new component that: • Accepts a `shipmentId` prop and fetches related settlements on mount. • Shows a loading spinner while fetching. • Shows an empty state (ShieldCheck icon + message) when no records exist. • Shows an error message if the fetch fails. • Renders each settlement record with: amount + token symbol, status badge with animated pulse for PENDING/ESCROWED states, and a `stellarTxHash` link to stellar.expert testnet explorer (with ExternalLink icon). Escrow release timestamp is shown when available. All styling follows the existing ShipmentDetail Tailwind dark-theme patterns (same card wrapper, same teal accent, same Bebas Neue heading style).
- Imported and rendered `<EscrowStatus shipmentId={id ?? shipmentId} />` in `pages/ShipmentDetail/ShipmentDetail.tsx`, placed between PaymentStatus and DeliveryProofUpload.
- Exported `EscrowStatus` and `EscrowStatusProps` from `pages/ShipmentDetail/index.ts`.

Files changed: `services/api/endpoints/settlements.ts`, `pages/ShipmentDetail/EscrowStatus/EscrowStatus.tsx` (new), `pages/ShipmentDetail/ShipmentDetail.tsx`,
`pages/ShipmentDetail/index.ts`

Closes #202
Closes #203
Closes #204
Closes #205