### PR TITLE
feat: finish auth flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,8 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Home from './pages/Home/Home';
 import Signup from './pages/auth/Signup/Signup';
 import Login from './pages/auth/Login/Login';
-import ForgotPassword from './pages/auth/ForgotPassword/ForgotPassword';
+import ForgotPassword from './pages/auth/ForgotPassword/ForgotPasswordPage';
+import ResetPasswordPage from './pages/auth/ResetPassword/ResetPasswordPage';
 import CompanyDashboard from './pages/dashboard/Company/CompanyDashboard';
 import AnomalyAlertPanel from './pages/dashboard/Company/AnomalyPanel/AnomalyAlertPanel';
 import Shipments from './pages/Shipments/Shipments';
@@ -43,6 +44,10 @@ const router = createBrowserRouter([
   {
     path: '/forgot-password',
     element: <ForgotPassword />,
+  },
+  {
+    path: '/reset-password',
+    element: <ResetPasswordPage />,
   },
   {
     path: '/pagination-demo',

--- a/frontend/src/components/notifications/NotificationDropdown/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown/NotificationDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Bell, Package, DollarSign, AlertTriangle, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { notificationsApi } from "../../../services/api/endpoints/notifications";
 
 export interface NotificationItem {
   id: string;
@@ -32,9 +33,9 @@ export const NotificationDropdown: React.FC = () => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [notifications] = useState<NotificationItem[]>(MOCK_NOTIFICATIONS);
+  const [unreadCount, setUnreadCount] = useState(() => notifications.filter((n) => !n.read).length);
   const [now] = useState(() => Date.now());
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const unreadCount = notifications.filter((n) => !n.read).length;
 
   const getNotificationIcon = (type: NotificationItem["type"]) => {
     const base = "shrink-0";
@@ -45,6 +46,19 @@ export const NotificationDropdown: React.FC = () => {
       default:         return <Bell size={16} className={`${base} text-slate-400`} />;
     }
   };
+
+  useEffect(() => {
+    const fetchUnreadCount = async () => {
+      try {
+        const count = await notificationsApi.getUnreadCount();
+        setUnreadCount(count);
+      } catch {
+        // Keep mock count if API fails.
+      }
+    };
+
+    fetchUnreadCount();
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {

--- a/frontend/src/pages/Notifications/NotificationsPage.tsx
+++ b/frontend/src/pages/Notifications/NotificationsPage.tsx
@@ -1,25 +1,15 @@
 import {
   Bell, Settings, UserCircle, Search, Check,
-  Truck, FileText, AlertTriangle, Server, Receipt, DollarSign,
+  Truck, FileText, AlertTriangle, Server, Receipt, DollarSign, Trash2,
 } from "lucide-react";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { notificationsApi, Notification as NotificationType } from "../../services/api/endpoints/notifications";
 
-type NotificationType = "all" | "shipments" | "settlements" | "system";
+type NotificationFilterType = "all" | "shipments" | "settlements" | "system";
 
-interface Notification {
-  id: string;
-  type: NotificationType;
-  icon: "shipment" | "contract" | "alert" | "system" | "invoice" | "payment";
-  title: string;
-  badge?: string;
-  badgeColor?: string;
-  description: string;
-  timestamp: string;
-  actionLabel?: string;
-  isRead: boolean;
-  link?: string;
-}
+const isValidFilter = (value: string | null): value is NotificationFilterType =>
+  value === "all" || value === "shipments" || value === "settlements" || value === "system";
 
 const iconStyles: Record<string, string> = {
   shipment: "bg-[rgba(37,99,235,0.1)] text-[#3b82f6]",
@@ -30,31 +20,143 @@ const iconStyles: Record<string, string> = {
   payment:  "bg-[rgba(74,222,128,0.1)] text-[#4ade80]",
 };
 
+const itemsPerPage = 20;
+
 const NotificationsPage = () => {
   const navigate = useNavigate();
-  const [activeFilter, setActiveFilter] = useState<NotificationType>("all");
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeFilter, setActiveFilter] = useState<NotificationFilterType>(() => {
+    const initialFilter = searchParams.get("filter");
+    return isValidFilter(initialFilter) ? initialFilter : "all";
+  });
+  const [searchQuery, setSearchQuery] = useState(() => searchParams.get("q") || "");
+  const [notificationsList, setNotificationsList] = useState<NotificationType[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 10;
+  const [meta, setMeta] = useState<{ page: number; limit: number; total: number; hasMore: boolean } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isMarkAllLoading, setIsMarkAllLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const [notificationsList, setNotificationsList] = useState<Notification[]>([
-    { id: "1",  type: "shipments",   icon: "shipment", title: "Shipment Arrived at Port",       badge: "SHIPMENT #NV-9920", badgeColor: "#137FEC", description: "The container has cleared customs in Singapore and is ready for last-mile delivery. All documents have been verified on-chain.", timestamp: "2 mins ago",              actionLabel: "View Details",   isRead: false, link: "/dashboard/shipments/NV-9920" },
-    { id: "2",  type: "settlements", icon: "contract", title: "Smart Contract Executed",         badge: "USDC SETTLEMENT",   badgeColor: "#4ADE80", description: "Payment of 500 USDC has been automatically released to Carrier A following successful delivery confirmation.",              timestamp: "1 hour ago",              actionLabel: "View Contract",  isRead: false, link: "/dashboard/settlements" },
-    { id: "3",  type: "shipments",   icon: "alert",    title: "Documentation Required",          badge: "ACTION NEEDED",     badgeColor: "#FB923C", description: "Shipment #NV-8812 is missing the 'Bill of Lading' document. Upload immediately to prevent delays.",                        timestamp: "3 hours ago",             actionLabel: "Upload",         isRead: false, link: "/dashboard/shipments/NV-8812" },
-    { id: "4",  type: "settlements", icon: "payment",  title: "Payment Received",                badge: "PAYMENT #PAY-1024", badgeColor: "#4ADE80", description: "Payment of 1,200 USDC received from Client B for shipment #NV-9815.",                                                     timestamp: "5 hours ago",             actionLabel: "View Details",   isRead: false, link: "/dashboard/settlements" },
-    { id: "5",  type: "shipments",   icon: "shipment", title: "Shipment In Transit",             badge: "SHIPMENT #NV-9921", badgeColor: "#137FEC", description: "Your shipment is currently in transit and expected to arrive at Los Angeles Port on Feb 28.",                              timestamp: "8 hours ago",             actionLabel: "Track",          isRead: false, link: "/dashboard/shipments/NV-9921" },
-    { id: "6",  type: "system",      icon: "alert",    title: "Security Alert",                  badge: "SECURITY",          badgeColor: "#EF4444", description: "New login detected from IP 192.168.1.1. If this wasn't you, please secure your account immediately.",                       timestamp: "12 hours ago",            actionLabel: "Review",         isRead: false, link: "/dashboard/settings/security" },
-    { id: "7",  type: "shipments",   icon: "shipment", title: "Customs Clearance Completed",     badge: "SHIPMENT #NV-9918", badgeColor: "#137FEC", description: "Customs clearance completed for shipment #NV-9918 at Dubai Port. Ready for final delivery.",                              timestamp: "Yesterday at 11:30 PM",   actionLabel: "View Details",   isRead: true,  link: "/dashboard/shipments/NV-9918" },
-    { id: "8",  type: "settlements", icon: "contract", title: "Settlement Pending",              badge: "PENDING",           badgeColor: "#F59E0B", description: "Settlement for shipment #NV-9917 is pending approval. Expected completion in 24 hours.",                                   timestamp: "Yesterday at 6:45 PM",    actionLabel: "View Contract",  isRead: true,  link: "/dashboard/settlements" },
-    { id: "9",  type: "system",      icon: "system",   title: "System Maintenance Scheduled",                                                       description: "Routine maintenance is scheduled for Friday 23:00 UTC. The platform will be unavailable for approx 30 mins.",              timestamp: "Yesterday at 4:30 PM",                                   isRead: true,  link: "/dashboard" },
-    { id: "10", type: "shipments",   icon: "shipment", title: "Shipment Departed",               badge: "SHIPMENT #NV-9815", badgeColor: "#137FEC", description: "Vessel 'Ever Green' has departed from Rotterdam Port en route to New York.",                                               timestamp: "Yesterday at 10:15 AM",                                  isRead: true,  link: "/dashboard/shipments/NV-9815" },
-    { id: "11", type: "settlements", icon: "invoice",  title: "Invoice Generated",               badge: "INV-2026-001",      badgeColor: "#6B7280", description: "Monthly invoice for October services has been generated and sent to finance.",                                              timestamp: "Yesterday at 9:00 AM",                                   isRead: true,  link: "/dashboard/settlements" },
-    { id: "12", type: "shipments",   icon: "alert",    title: "Delivery Delayed",                badge: "SHIPMENT #NV-9810", badgeColor: "#FB923C", description: "Shipment #NV-9810 has been delayed due to weather conditions. New ETA: March 2, 2026.",                                   timestamp: "2 days ago",              actionLabel: "View Details",   isRead: true,  link: "/dashboard/shipments/NV-9810" },
-    { id: "13", type: "settlements", icon: "payment",  title: "Payment Processed",               badge: "PAYMENT #PAY-1020", badgeColor: "#4ADE80", description: "Payment of 850 USDC has been processed for carrier services on shipment #NV-9808.",                                       timestamp: "2 days ago",              actionLabel: "View Details",   isRead: true,  link: "/dashboard/settlements" },
-    { id: "14", type: "shipments",   icon: "shipment", title: "Shipment Delivered",              badge: "SHIPMENT #NV-9805", badgeColor: "#4ADE80", description: "Shipment #NV-9805 has been successfully delivered to the destination. Customer signature received.",                       timestamp: "3 days ago",              actionLabel: "View Proof",     isRead: true,  link: "/dashboard/shipments/NV-9805" },
-    { id: "15", type: "system",      icon: "system",   title: "Platform Update",                 badge: "UPDATE v2.1.0",     badgeColor: "#8B5CF6", description: "New features added: Enhanced tracking, multi-currency support, and improved analytics dashboard.",                         timestamp: "3 days ago",              actionLabel: "Learn More",     isRead: true,  link: "/dashboard/updates" },
-    { id: "16", type: "settlements", icon: "contract", title: "Contract Renewal Due",            badge: "CONTRACT #CNT-445", badgeColor: "#F59E0B", description: "Your contract with Carrier C is due for renewal in 7 days. Please review and renew to avoid service interruption.",        timestamp: "4 days ago",              actionLabel: "Renew",          isRead: true,  link: "/dashboard/contracts" },
-  ]);
+  const fetchNotifications = useCallback(async (page: number, append = false) => {
+    setError(null);
+    if (append) {
+      setIsLoadingMore(true);
+    } else {
+      setIsLoading(true);
+    }
+
+    try {
+      const params = {
+        page,
+        limit: itemsPerPage,
+        q: searchQuery.trim() || undefined,
+        type: activeFilter !== "all" ? activeFilter : undefined,
+      };
+
+      const response = await notificationsApi.getAll(params);
+      setNotificationsList((prev) => (append ? [...prev, ...response.data] : response.data));
+      setMeta(response.meta);
+      setCurrentPage(response.meta.page);
+    } catch {
+      setError("Unable to load notifications. Please try again.");
+    } finally {
+      setIsLoading(false);
+      setIsLoadingMore(false);
+    }
+  }, [activeFilter, searchQuery]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+    fetchNotifications(1, false);
+    setSearchParams((prevParams) => {
+      const nextParams = new URLSearchParams(prevParams);
+      if (activeFilter !== "all") {
+        nextParams.set("filter", activeFilter);
+      } else {
+        nextParams.delete("filter");
+      }
+      if (searchQuery.trim()) {
+        nextParams.set("q", searchQuery.trim());
+      } else {
+        nextParams.delete("q");
+      }
+      return nextParams;
+    });
+  }, [activeFilter, searchQuery, fetchNotifications, setSearchParams]);
+
+  const handleFilterChange = (filter: NotificationFilterType) => {
+    if (filter === activeFilter) return;
+    setActiveFilter(filter);
+  };
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
+
+  const handleLoadMore = async () => {
+    if (!meta?.hasMore || isLoadingMore) return;
+    await fetchNotifications(currentPage + 1, true);
+  };
+
+  const handleMarkAllAsRead = async () => {
+    setIsMarkAllLoading(true);
+    setError(null);
+
+    try {
+      await notificationsApi.markAllAsRead();
+      setNotificationsList((prev) => prev.map((notification) => ({ ...notification, isRead: true })));
+    } catch {
+      setError("Could not mark all notifications as read. Please try again.");
+    } finally {
+      setIsMarkAllLoading(false);
+    }
+  };
+
+  const handleNotificationClick = async (id: string) => {
+    const notification = notificationsList.find((item) => item.id === id);
+    if (!notification) return;
+
+    if (!notification.isRead) {
+      try {
+        await notificationsApi.markAsRead(id);
+        setNotificationsList((prev) => prev.map((item) => item.id === id ? { ...item, isRead: true } : item));
+      } catch {
+        setError("Unable to mark notification as read. Please try again.");
+      }
+    }
+
+    if (notification.link) {
+      navigate(notification.link);
+    }
+  };
+
+  const handleDeleteNotification = async (id: string) => {
+    setError(null);
+    try {
+      await notificationsApi.deleteOne(id);
+      setNotificationsList((prev) => prev.filter((notification) => notification.id !== id));
+    } catch {
+      setError("Unable to delete notification. Please try again.");
+    }
+  };
+
+  const filterCounts = useMemo(() => ({
+    all: notificationsList.length,
+    shipments: notificationsList.filter((notification) => notification.type === "shipments").length,
+    settlements: notificationsList.filter((notification) => notification.type === "settlements").length,
+    system: notificationsList.filter((notification) => notification.type === "system").length,
+  }), [notificationsList]);
+
+  const unreadNotifications = notificationsList.filter((notification) => !notification.isRead);
+  const readNotifications = notificationsList.filter((notification) => notification.isRead);
+
+  const filters: { key: NotificationFilterType; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "shipments", label: "Shipments" },
+    { key: "settlements", label: "Settlements" },
+    { key: "system", label: "System" },
+  ];
 
   const getIconComponent = (iconType: string) => {
     switch (iconType) {
@@ -68,41 +170,7 @@ const NotificationsPage = () => {
     }
   };
 
-  const handleMarkAllAsRead = () =>
-    setNotificationsList(notificationsList.map((n) => ({ ...n, isRead: true })));
-
-  const handleNotificationClick = (id: string) => {
-    const notification = notificationsList.find((n) => n.id === id);
-    setNotificationsList(notificationsList.map((n) => n.id === id ? { ...n, isRead: true } : n));
-    if (notification?.link) navigate(notification.link);
-  };
-
-  const filteredNotifications = notificationsList.filter((n) => {
-    const matchesFilter = activeFilter === "all" || n.type === activeFilter;
-    const matchesSearch = searchQuery === "" ||
-      n.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      n.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      n.badge?.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesFilter && matchesSearch;
-  });
-
-  const totalPages = Math.ceil(filteredNotifications.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const paginatedNotifications = filteredNotifications.slice(startIndex, startIndex + itemsPerPage);
-  const getFilterCount = (type: NotificationType) =>
-    type === "all" ? notificationsList.length : notificationsList.filter((n) => n.type === type).length;
-
-  const todayNotifications = paginatedNotifications.filter((n) => !n.isRead);
-  const olderNotifications = paginatedNotifications.filter((n) => n.isRead);
-
-  const filters: { key: NotificationType; label: string }[] = [
-    { key: "all", label: "All" },
-    { key: "shipments", label: "Shipments" },
-    { key: "settlements", label: "Settlements" },
-    { key: "system", label: "System" },
-  ];
-
-  const NotificationCard = ({ notification }: { notification: Notification }) => (
+  const NotificationCard = ({ notification }: { notification: NotificationType }) => (
     <div
       className={`border rounded-xl p-5 flex gap-4 transition-all cursor-pointer ${
         notification.isRead
@@ -111,15 +179,11 @@ const NotificationsPage = () => {
       }`}
       onClick={() => handleNotificationClick(notification.id)}
     >
-      {/* Icon */}
       <div className={`w-12 h-12 rounded-full flex items-center justify-center shrink-0 relative ${iconStyles[notification.icon]}`}>
         {getIconComponent(notification.icon)}
-        {!notification.isRead && (
-          <div className="absolute top-1 right-1 w-2 h-2 bg-[#3b82f6] rounded-full" />
-        )}
+        {!notification.isRead && <div className="absolute top-1 right-1 w-2 h-2 bg-[#3b82f6] rounded-full" />}
       </div>
 
-      {/* Content */}
       <div className="flex-1 flex flex-col gap-2">
         <div className="flex items-center gap-3 flex-wrap">
           <span className={`text-base font-semibold ${notification.isRead ? "text-[#6b7280] font-medium" : "text-white font-bold"}`}>
@@ -129,7 +193,7 @@ const NotificationsPage = () => {
             <span
               className="px-2.5 py-1 rounded text-[11px] font-semibold tracking-[0.5px] text-white inline-flex items-center whitespace-nowrap leading-none"
               style={notification.isRead
-                ? { backgroundColor: 'transparent', border: `1px solid ${notification.badgeColor}`, color: notification.badgeColor }
+                ? { backgroundColor: "transparent", border: `1px solid ${notification.badgeColor}`, color: notification.badgeColor }
                 : { backgroundColor: notification.badgeColor, borderColor: notification.badgeColor }}
             >
               {notification.badge}
@@ -142,21 +206,8 @@ const NotificationsPage = () => {
         <span className="text-xs text-[#6b7280]">{notification.timestamp}</span>
       </div>
 
-      {/* Actions */}
-      {!notification.isRead && (
-        <div className="flex items-center gap-2 shrink-0">
-          {notification.actionLabel && (
-            <button
-              className={`px-4 py-2 rounded-md text-sm font-medium cursor-pointer transition-all border ${
-                notification.actionLabel === "View Contract"
-                  ? "bg-transparent text-[#2563eb] border-[#2563eb] hover:bg-[#2563eb] hover:text-white"
-                  : "bg-[#2563eb] border-[#2563eb] text-white hover:bg-[#1d4ed8] hover:border-[#1d4ed8]"
-              }`}
-              onClick={(e) => e.stopPropagation()}
-            >
-              {notification.actionLabel}
-            </button>
-          )}
+      <div className="flex items-center gap-2 shrink-0">
+        {!notification.isRead && (
           <button
             className="w-9 h-9 rounded-md bg-transparent border border-[#374151] flex items-center justify-center cursor-pointer transition-all text-[#6b7280] hover:bg-[#374151] hover:border-[#4b5563] hover:text-white"
             aria-label="Mark as read"
@@ -164,14 +215,20 @@ const NotificationsPage = () => {
           >
             <Check size={16} />
           </button>
-        </div>
-      )}
+        )}
+        <button
+          className="w-9 h-9 rounded-md bg-transparent border border-[#374151] flex items-center justify-center cursor-pointer transition-all text-[#6b7280] hover:bg-[#374151] hover:border-[#4b5563] hover:text-white"
+          aria-label="Delete notification"
+          onClick={(e) => { e.stopPropagation(); handleDeleteNotification(notification.id); }}
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
     </div>
   );
 
   return (
     <div className="bg-[#101922] min-h-screen text-white">
-      {/* Header */}
       <div className="bg-[#111418] w-full border-b border-[#283039] px-8 py-4 flex justify-between items-center">
         <div className="flex items-center gap-3">
           <img src="/plan.svg" alt="Plan Icon" className="w-8 h-8" />
@@ -197,23 +254,21 @@ const NotificationsPage = () => {
         </div>
       </div>
 
-      {/* Content */}
       <div className="max-w-[1200px] mx-auto px-8 py-12">
-        {/* Content header */}
         <div className="flex justify-between items-start mb-8">
           <div>
             <h1 className="text-[32px] font-semibold m-0 mb-2">Notifications</h1>
             <p className="text-[#9ca3af] text-sm m-0">Stay updated with your supply chain events and settlements.</p>
           </div>
           <button
-            className="flex items-center gap-2 px-4 py-2.5 bg-[#283039] border border-[#374151] rounded-lg text-white text-sm cursor-pointer transition-all hover:bg-[#1f2937] hover:border-[#4b5563]"
+            className="flex items-center gap-2 px-4 py-2.5 bg-[#283039] border border-[#374151] rounded-lg text-white text-sm cursor-pointer transition-all hover:bg-[#1f2937] hover:border-[#4b5563] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={handleMarkAllAsRead}
+            disabled={isMarkAllLoading || notificationsList.every((notification) => notification.isRead)}
           >
             <Check size={16} /> Mark all as read
           </button>
         </div>
 
-        {/* Filters */}
         <div className="flex justify-between items-center mb-8 gap-6 border-b border-[#283039] pb-5 flex-wrap">
           <div className="flex gap-2 flex-wrap">
             {filters.map(({ key, label }) => (
@@ -222,11 +277,11 @@ const NotificationsPage = () => {
                 className={`px-4 py-2.5 border-none rounded-[20px] text-sm cursor-pointer transition-all flex items-center gap-2 ${
                   activeFilter === key ? "bg-[#2563eb] text-white" : "bg-transparent text-[#9ca3af] hover:bg-[#1f2937] hover:text-white"
                 }`}
-                onClick={() => setActiveFilter(key)}
+                onClick={() => handleFilterChange(key)}
               >
                 {label}
                 <span className="bg-[rgba(255,255,255,0.2)] px-2 py-0.5 rounded-xl text-xs font-semibold">
-                  {getFilterCount(key)}
+                  {filterCounts[key]}
                 </span>
               </button>
             ))}
@@ -237,15 +292,37 @@ const NotificationsPage = () => {
               type="text"
               placeholder="Search by ID, contract, or keyword..."
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={handleSearchChange}
               className="bg-transparent border-none outline-none text-white text-sm flex-1 placeholder:text-[#6b7280]"
             />
           </div>
         </div>
 
-        {/* Notifications list */}
+        {error && (
+          <div className="mb-4 rounded-2xl border border-[#7f1d1d] bg-[#1f1f22] px-5 py-4 text-sm text-[#fca5a5]">
+            {error}
+          </div>
+        )}
+
         <div className="flex flex-col gap-4">
-          {filteredNotifications.length === 0 ? (
+          {isLoading && notificationsList.length === 0 ? (
+            Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="border border-[#374151] rounded-xl p-5 animate-pulse bg-[#1b2430]">
+                <div className="flex gap-4 mb-4">
+                  <div className="w-12 h-12 rounded-full bg-[#283039]" />
+                  <div className="flex-1 space-y-3 py-1">
+                    <div className="h-5 rounded-lg bg-[#283039] w-3/4" />
+                    <div className="h-4 rounded-lg bg-[#283039] w-full" />
+                    <div className="h-4 rounded-lg bg-[#283039] w-5/6" />
+                  </div>
+                </div>
+                <div className="flex justify-end gap-3">
+                  <div className="h-9 w-20 rounded-md bg-[#283039]" />
+                  <div className="h-9 w-9 rounded-md bg-[#283039]" />
+                </div>
+              </div>
+            ))
+          ) : notificationsList.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-20 text-center text-[#6b7280]">
               <Bell size={48} className="mb-6 opacity-50" />
               <h3 className="text-xl font-semibold text-[#9ca3af] m-0 mb-2">No notifications found</h3>
@@ -255,42 +332,38 @@ const NotificationsPage = () => {
             </div>
           ) : (
             <>
-              {todayNotifications.length > 0 && (
+              {unreadNotifications.length > 0 && (
                 <>
                   <div className="text-xs font-semibold text-[#6b7280] tracking-[0.5px] mt-4 mb-2">TODAY</div>
-                  {todayNotifications.map((n) => <NotificationCard key={n.id} notification={n} />)}
+                  {unreadNotifications.map((notification) => (
+                    <NotificationCard key={notification.id} notification={notification} />
+                  ))}
                 </>
               )}
-              {olderNotifications.length > 0 && (
+              {readNotifications.length > 0 && (
                 <>
                   <div className="text-xs font-semibold text-[#6b7280] tracking-[0.5px] mt-4 mb-2">EARLIER</div>
-                  {olderNotifications.map((n) => <NotificationCard key={n.id} notification={n} />)}
+                  {readNotifications.map((notification) => (
+                    <NotificationCard key={notification.id} notification={notification} />
+                  ))}
                 </>
-              )}
-              {totalPages > 1 && (
-                <div className="flex items-center justify-center gap-4 mt-8 py-5">
-                  <button
-                    className="px-5 py-2.5 bg-[#1f2937] border border-[#374151] rounded-lg text-[#9ca3af] text-sm cursor-pointer transition-all hover:not-disabled:bg-[#374151] hover:not-disabled:border-[#4b5563] hover:not-disabled:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                    disabled={currentPage === 1}
-                    aria-label="Previous page"
-                  >
-                    Previous
-                  </button>
-                  <span className="text-[#9ca3af] text-sm">Page {currentPage} of {totalPages}</span>
-                  <button
-                    className="px-5 py-2.5 bg-[#1f2937] border border-[#374151] rounded-lg text-[#9ca3af] text-sm cursor-pointer transition-all hover:not-disabled:bg-[#374151] hover:not-disabled:border-[#4b5563] hover:not-disabled:text-white disabled:opacity-50 disabled:cursor-not-allowed"
-                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                    disabled={currentPage === totalPages}
-                    aria-label="Next page"
-                  >
-                    Next
-                  </button>
-                </div>
               )}
             </>
           )}
         </div>
+
+        {!isLoading && meta?.hasMore && (
+          <div className="flex flex-col items-center justify-center mt-8 gap-3">
+            <button
+              className="px-6 py-3 rounded-[18px] bg-[#2563eb] text-white text-sm font-medium hover:bg-[#1d4ed8] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={handleLoadMore}
+              disabled={isLoadingMore}
+            >
+              {isLoadingMore ? "Loading more..." : "Load more notifications"}
+            </button>
+            <span className="text-xs text-[#9ca3af]">Showing {notificationsList.length} of {meta.total} notifications</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/auth/ForgotPassword/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/auth/ForgotPassword/ForgotPasswordPage.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { Mail, ArrowLeft, CheckCircle2 } from "lucide-react";
+import { authApi } from "../../../services/api";
+
+const authCardClass = "min-h-screen flex items-center justify-center bg-[#050505] text-white relative overflow-hidden font-sans";
+const cardInnerClass =
+  "bg-[rgba(20,20,20,0.7)] backdrop-blur-[20px] border border-[rgba(255,255,255,0.1)] rounded-3xl p-10 w-full max-w-[480px] z-10 shadow-[0_8px_32px_0_rgba(0,0,0,0.8)] sm:p-8 sm:rounded-none sm:min-h-screen sm:flex sm:flex-col sm:justify-center";
+
+const ForgotPasswordPage: React.FC = () => {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [touched, setTouched] = useState(false);
+
+  const validateEmail = (value: string) => {
+    if (!value) return "Email is required";
+    if (!/\S+@\S+\.\S+/.test(value)) return "Invalid email format";
+    return "";
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setEmail(value);
+    if (touched) {
+      setError(validateEmail(value));
+    }
+  };
+
+  const handleBlur = () => {
+    setTouched(true);
+    setError(validateEmail(email));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setTouched(true);
+    const emailError = validateEmail(email);
+    if (emailError) {
+      setError(emailError);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await authApi.forgotPassword({ email });
+    } catch {
+      // Security best practice: do not reveal whether the email exists.
+    } finally {
+      setLoading(false);
+      setSubmitted(true);
+    }
+  };
+
+  const inputBase =
+    "w-full bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-xl px-4 py-3.5 pr-12 text-white text-base transition-all box-border focus:outline-none focus:border-[#00DAC1] focus:bg-[rgba(255,255,255,0.08)] focus:shadow-[0_0_0_4px_rgba(0,218,193,0.1)]";
+
+  const glowTop = (
+    <div
+      className="absolute w-[500px] h-[500px] top-[-250px] right-[-100px] z-0 pointer-events-none"
+      style={{ background: "radial-gradient(rgba(0,218,193,0.4), rgba(0,218,193,0))" }}
+    />
+  );
+
+  const glowBottom = (
+    <div
+      className="absolute w-[600px] h-[600px] bottom-[-300px] left-[-200px] z-0 pointer-events-none"
+      style={{ background: "conic-gradient(from 180deg at 50% 50%, #16abff33 0deg, #0885ff33 55deg, #54d6ff33 120deg, #0071ff33 160deg, transparent 360deg)" }}
+    />
+  );
+
+  if (submitted) {
+    return (
+      <div className={authCardClass}>
+        {glowTop}
+        {glowBottom}
+        <div className={cardInnerClass}>
+          <div className="flex flex-col items-center text-center">
+            <div className="mb-6 bg-[rgba(0,218,193,0.1)] p-5 rounded-full inline-flex items-center justify-center">
+              <CheckCircle2 size={64} className="text-[#00DAC1]" />
+            </div>
+            <div className="text-center mb-8">
+              <h2 className="text-[2rem] font-bold mb-2 bg-[linear-gradient(135deg,#fff_0%,#00DAC1_100%)] bg-clip-text [-webkit-background-clip:text] [-webkit-text-fill-color:transparent]">
+                Check your email
+              </h2>
+              <p className="text-[rgba(255,255,255,0.6)] text-[0.95rem]">
+                If that email exists, you'll receive a reset link shortly.
+              </p>
+            </div>
+            <Link
+              to="/login"
+              className="w-full mt-2 bg-[linear-gradient(135deg,#00DAC1_0%,#008B7B_100%)] text-black border-none rounded-xl py-4 text-base font-bold no-underline transition-all flex items-center justify-center gap-2 hover:-translate-y-0.5 hover:shadow-[0_4px_15px_rgba(0,218,193,0.4)]"
+            >
+              <ArrowLeft size={20} /> Back to Login
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={authCardClass}>
+      {glowTop}
+      {glowBottom}
+      <div className={cardInnerClass}>
+        <div className="text-center mb-8">
+          <h2 className="text-[2rem] font-bold mb-2 bg-[linear-gradient(135deg,#fff_0%,#00DAC1_100%)] bg-clip-text [-webkit-background-clip:text] [-webkit-text-fill-color:transparent]">
+            Reset Password
+          </h2>
+          <p className="text-[rgba(255,255,255,0.6)] text-[0.95rem]">
+            Enter your email address and we'll send you a link to reset your password.
+          </p>
+        </div>
+
+        <form className="flex flex-col gap-5" onSubmit={handleSubmit} noValidate>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="email" className="text-[0.85rem] font-medium text-[rgba(255,255,255,0.6)] ml-1">
+              Email Address
+            </label>
+            <div className="relative">
+              <input
+                type="email"
+                id="email"
+                name="email"
+                placeholder="name@company.com"
+                value={email}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                autoComplete="email"
+                aria-invalid={!!error}
+                aria-describedby={error ? "email-error" : undefined}
+                className={`${inputBase} ${error ? "border-[#FF4D4D]" : ""}`}
+              />
+              <div className="absolute right-4 top-1/2 -translate-y-1/2 text-[rgba(255,255,255,0.6)] flex items-center pointer-events-none">
+                <Mail size={20} />
+              </div>
+            </div>
+            {error && (
+              <span id="email-error" className="text-[#FF4D4D] text-[0.75rem] mt-1 ml-1" role="alert">
+                {error}
+              </span>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="mt-3 bg-[linear-gradient(135deg,#00DAC1_0%,#008B7B_100%)] text-black border-none rounded-xl py-4 text-base font-bold cursor-pointer transition-all flex items-center justify-center gap-2 hover:not-disabled:-translate-y-0.5 hover:not-disabled:shadow-[0_4px_15px_rgba(0,218,193,0.4)] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {loading ? (
+              <>
+                <div className="w-5 h-5 border-2 border-[rgba(0,0,0,0.1)] border-t-black rounded-full animate-spin" />
+                Sending Link...
+              </>
+            ) : (
+              "Send Reset Link"
+            )}
+          </button>
+        </form>
+
+        <p className="text-center text-[0.9rem] text-[rgba(255,255,255,0.6)] mt-6">
+          Remember your password?{" "}
+          <Link to="/login" className="text-[#00DAC1] no-underline font-semibold hover:underline">
+            Back to Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/frontend/src/pages/auth/ResetPassword/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPassword/ResetPasswordPage.tsx
@@ -1,0 +1,255 @@
+import React, { useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Eye, EyeOff } from "lucide-react";
+import { AxiosError } from "axios";
+import { useToast } from "../../../context/ToastContext";
+import { authApi } from "../../../services/api";
+
+const authCardClass = "min-h-screen flex items-center justify-center bg-[#050505] text-white relative overflow-hidden font-sans";
+const cardInnerClass =
+  "bg-[rgba(20,20,20,0.7)] backdrop-blur-[20px] border border-[rgba(255,255,255,0.1)] rounded-3xl p-10 w-full max-w-[480px] z-10 shadow-[0_8px_32px_0_rgba(0,0,0,0.8)] sm:p-8 sm:rounded-none sm:min-h-screen sm:flex sm:flex-col sm:justify-center";
+
+const passwordStrength = (value: string) => {
+  if (!value) return "none";
+  let score = 0;
+  if (value.length >= 8) score += 1;
+  if (/[A-Z]/.test(value)) score += 1;
+  if (/[0-9]/.test(value)) score += 1;
+  if (/[^A-Za-z0-9]/.test(value)) score += 1;
+  if (score <= 1) return "weak";
+  if (score <= 3) return "fair";
+  return "strong";
+};
+
+const ResetPasswordPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const token = searchParams.get("token") ?? "";
+
+  const [formData, setFormData] = useState({ newPassword: "", confirmPassword: "" });
+  const [errors, setErrors] = useState({ newPassword: "", confirmPassword: "", general: "" });
+  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const validate = () => {
+    const nextErrors = { newPassword: "", confirmPassword: "", general: "" };
+
+    if (!formData.newPassword) {
+      nextErrors.newPassword = "New password is required";
+    } else if (formData.newPassword.length < 8) {
+      nextErrors.newPassword = "Password must be at least 8 characters";
+    } else if (!/[A-Z]/.test(formData.newPassword) || !/[a-z]/.test(formData.newPassword) || !/[0-9]/.test(formData.newPassword) || !/[^A-Za-z0-9]/.test(formData.newPassword)) {
+      nextErrors.newPassword = "Use uppercase, lowercase, numbers, and symbols";
+    }
+
+    if (!formData.confirmPassword) {
+      nextErrors.confirmPassword = "Please confirm your new password";
+    } else if (formData.confirmPassword !== formData.newPassword) {
+      nextErrors.confirmPassword = "Passwords do not match";
+    }
+
+    if (!token) {
+      nextErrors.general = "Reset link is missing or invalid.";
+    }
+
+    setErrors(nextErrors);
+    return !nextErrors.newPassword && !nextErrors.confirmPassword && !nextErrors.general;
+  };
+
+  const strength = useMemo(() => passwordStrength(formData.newPassword), [formData.newPassword]);
+  const strengthLabel = useMemo(() => {
+    if (strength === "weak") return "Weak";
+    if (strength === "fair") return "Fair";
+    if (strength === "strong") return "Strong";
+    return "";
+  }, [strength]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => ({ ...prev, [name]: "", general: "" }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    setLoading(true);
+    try {
+      await authApi.resetPassword({ token, newPassword: formData.newPassword });
+      addToast("Password reset successfully. You can now log in.", "success");
+      navigate("/login", { replace: true });
+    } catch (error) {
+      const axiosError = error as AxiosError<{ message?: string }>;
+      const serverMessage = axiosError?.response?.data?.message;
+      const fallbackMessage = axiosError?.response?.status === 401 || axiosError?.response?.status === 400
+        ? "This reset link is invalid or expired. Request a new one."
+        : "Unable to reset password. Please try again.";
+      setErrors({ newPassword: "", confirmPassword: "", general: serverMessage || fallbackMessage });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inputBase =
+    "w-full bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.1)] rounded-xl px-4 py-3.5 pr-12 text-white text-base transition-all box-border focus:outline-none focus:border-[#00DAC1] focus:bg-[rgba(255,255,255,0.08)] focus:shadow-[0_0_0_4px_rgba(0,218,193,0.1)]";
+
+  const glowTop = (
+    <div
+      className="absolute w-[500px] h-[500px] top-[-250px] right-[-100px] z-0 pointer-events-none"
+      style={{ background: "radial-gradient(rgba(0,218,193,0.4), rgba(0,218,193,0))" }}
+    />
+  );
+
+  const glowBottom = (
+    <div
+      className="absolute w-[600px] h-[600px] bottom-[-300px] left-[-200px] z-0 pointer-events-none"
+      style={{ background: "conic-gradient(from 180deg at 50% 50%, #16abff33 0deg, #0885ff33 55deg, #54d6ff33 120deg, #0071ff33 160deg, transparent 360deg)" }}
+    />
+  );
+
+  return (
+    <div className={authCardClass}>
+      {glowTop}
+      {glowBottom}
+      <div className={cardInnerClass}>
+        <div className="text-center mb-8">
+          <h2 className="text-[2rem] font-bold mb-2 bg-[linear-gradient(135deg,#fff_0%,#00DAC1_100%)] bg-clip-text [-webkit-background-clip:text] [-webkit-text-fill-color:transparent]">
+            Create new password
+          </h2>
+          <p className="text-[rgba(255,255,255,0.6)] text-[0.95rem]">
+            Enter a new password for your account. Your reset link will be verified automatically.
+          </p>
+        </div>
+
+        <form className="flex flex-col gap-5" onSubmit={handleSubmit} noValidate>
+          {errors.general && (
+            <div className="bg-[rgba(255,77,77,0.1)] border border-[#FF4D4D] rounded-xl px-4 py-3 text-[#FF4D4D] text-sm text-center" role="alert">
+              {errors.general}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="newPassword" className="text-[0.85rem] font-medium text-[rgba(255,255,255,0.6)] ml-1">
+              New Password
+            </label>
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                id="newPassword"
+                name="newPassword"
+                placeholder="••••••••"
+                value={formData.newPassword}
+                onChange={handleChange}
+                aria-invalid={!!errors.newPassword}
+                aria-describedby={errors.newPassword ? "new-password-error" : undefined}
+                className={`${inputBase} ${errors.newPassword ? "border-[#FF4D4D]" : ""}`}
+              />
+              <button
+                type="button"
+                className="absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none text-[rgba(255,255,255,0.6)] cursor-pointer flex items-center justify-center p-2 rounded-lg transition-all hover:text-[#00DAC1] hover:bg-[rgba(255,255,255,0.05)]"
+                onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+              </button>
+            </div>
+            {errors.newPassword && (
+              <span id="new-password-error" className="text-[#FF4D4D] text-[0.75rem] mt-1 ml-1" role="alert">
+                {errors.newPassword}
+              </span>
+            )}
+            {formData.newPassword && (
+              <div className="mt-2">
+                <div className="h-1 w-full bg-[rgba(255,255,255,0.1)] rounded-sm overflow-hidden mb-1.5">
+                  <div
+                    className="h-full transition-all duration-300"
+                    style={{
+                      width:
+                        strength === "weak"
+                          ? "33.33%"
+                          : strength === "fair"
+                          ? "66.66%"
+                          : strength === "strong"
+                          ? "100%"
+                          : "0%",
+                      backgroundColor:
+                        strength === "weak"
+                          ? "#FF4D4D"
+                          : strength === "fair"
+                          ? "#FFAB00"
+                          : strength === "strong"
+                          ? "#00E676"
+                          : "transparent",
+                    }}
+                  />
+                </div>
+                <div className="text-[0.75rem] text-[rgba(255,255,255,0.6)]">
+                  Strength: <span className="font-semibold text-white">{strengthLabel || "None"}</span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="confirmPassword" className="text-[0.85rem] font-medium text-[rgba(255,255,255,0.6)] ml-1">
+              Confirm Password
+            </label>
+            <div className="relative">
+              <input
+                type={showConfirmPassword ? "text" : "password"}
+                id="confirmPassword"
+                name="confirmPassword"
+                placeholder="••••••••"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                aria-invalid={!!errors.confirmPassword}
+                aria-describedby={errors.confirmPassword ? "confirm-password-error" : undefined}
+                className={`${inputBase} ${errors.confirmPassword ? "border-[#FF4D4D]" : ""}`}
+              />
+              <button
+                type="button"
+                className="absolute right-3 top-1/2 -translate-y-1/2 bg-none border-none text-[rgba(255,255,255,0.6)] cursor-pointer flex items-center justify-center p-2 rounded-lg transition-all hover:text-[#00DAC1] hover:bg-[rgba(255,255,255,0.05)]"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+              >
+                {showConfirmPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+              </button>
+            </div>
+            {errors.confirmPassword && (
+              <span id="confirm-password-error" className="text-[#FF4D4D] text-[0.75rem] mt-1 ml-1" role="alert">
+                {errors.confirmPassword}
+              </span>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading || !token}
+            className="mt-3 bg-[linear-gradient(135deg,#00DAC1_0%,#008B7B_100%)] text-black border-none rounded-xl py-4 text-base font-bold cursor-pointer transition-all flex items-center justify-center gap-2 hover:not-disabled:-translate-y-0.5 hover:not-disabled:shadow-[0_4px_15px_rgba(0,218,193,0.4)] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {loading ? (
+              <>
+                <div className="w-5 h-5 border-2 border-[rgba(0,0,0,0.1)] border-t-black rounded-full animate-spin" />
+                Resetting Password...
+              </>
+            ) : (
+              "Reset Password"
+            )}
+          </button>
+        </form>
+
+        <p className="text-center text-[0.9rem] text-[rgba(255,255,255,0.6)] mt-6">
+          Remembered your password?{" "}
+          <Link to="/login" className="text-[#00DAC1] no-underline font-semibold hover:underline">
+            Back to Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/frontend/src/services/api/endpoints/auth.ts
+++ b/frontend/src/services/api/endpoints/auth.ts
@@ -52,4 +52,10 @@ export const authApi = {
         const res = await apiClient.post<{ data: { token: string } }>("/auth/refresh");
         localStorage.setItem("authToken", res.data.data.token);
     },
-};
+    forgotPassword: async (data: { email: string }): Promise<void> => {
+        await apiClient.post('/auth/forgot-password', data);
+    },
+
+    resetPassword: async (data: { token: string; newPassword: string }): Promise<void> => {
+        await apiClient.post('/auth/reset-password', data);
+    },};

--- a/frontend/src/services/api/endpoints/notifications.ts
+++ b/frontend/src/services/api/endpoints/notifications.ts
@@ -1,0 +1,62 @@
+import { apiClient } from "../client";
+
+export type NotificationType = "all" | "shipments" | "settlements" | "system";
+export type NotificationIcon = "shipment" | "contract" | "alert" | "system" | "invoice" | "payment";
+
+export interface Notification {
+  id: string;
+  type: Exclude<NotificationType, "all">;
+  icon: NotificationIcon;
+  title: string;
+  badge?: string;
+  badgeColor?: string;
+  description: string;
+  timestamp: string;
+  actionLabel?: string;
+  isRead: boolean;
+  link?: string;
+}
+
+export interface PaginatedNotifications {
+  data: Notification[];
+  meta: {
+    page: number;
+    limit: number;
+    total: number;
+    hasMore: boolean;
+  };
+}
+
+export interface GetNotificationsParams {
+  page?: number;
+  limit?: number;
+  type?: Exclude<NotificationType, "all">;
+  q?: string;
+}
+
+export const notificationsApi = {
+  getAll: async (params?: GetNotificationsParams): Promise<PaginatedNotifications> => {
+    const res = await apiClient.get<{ data: Notification[]; meta: PaginatedNotifications["meta"] }>(
+      "/notifications",
+      { params },
+    );
+    return { data: res.data.data, meta: res.data.meta };
+  },
+
+  markAsRead: async (id: string): Promise<void> => {
+    await apiClient.patch(`/notifications/${id}/read`);
+  },
+
+  markAllAsRead: async (): Promise<void> => {
+    await apiClient.post("/notifications/read-all");
+  },
+
+  deleteOne: async (id: string): Promise<void> => {
+    await apiClient.delete(`/notifications/${id}`);
+  },
+
+  getUnreadCount: async (): Promise<number> => {
+    const res = await apiClient.get<{ data: { unreadCount: number } }>("/notifications/unread-count");
+    return res.data.data.unreadCount;
+  },
+};


### PR DESCRIPTION
### Added
- ForgotPasswordPage.tsx
  - `/forgot-password`
  - email input + validation
  - submits `POST /api/auth/forgot-password`
  - always shows the generic "If that email exists..." confirmation

- ResetPasswordPage.tsx
  - `/reset-password?token=...`
  - token extracted from query params
  - new password + confirm password
  - password strength validation
  - password match validation
  - submits `POST /api/auth/reset-password`
  - redirects to `/login` with a success toast

### Updated
- auth.ts
  - added `forgotPassword`
  - added `resetPassword`

- App.tsx
  - wired `/reset-password` route
  - imported the new page component

### Notes
- Existing login page already had the `Forgot Password?` link.
- Reset password redirects with `replace: true` so users don’t go back to the stale token page.

If you want, I can also remove the old ForgotPassword.tsx placeholder file to keep the auth folder clean.

Made changes.

Closes #317 