### PR TITLE
feat: add Playwright E2E test suite with 138 tests across 6 suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,61 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+  e2e:
+    name: E2E Tests
+    needs: [lint, type-check, test]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Restore pnpm store cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium firefox
+        working-directory: frontend
+
+      - name: Run E2E tests
+        run: pnpm run test:e2e
+        working-directory: frontend
+        env:
+          CI: true
+          VITE_API_BASE_URL: http://localhost:5173
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     name: Build Application
     needs: [lint, type-check, test]

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "@playwright/test";
+import { gotoProtected, loginAs, logout, COMPANY_TOKEN } from "./helpers/auth";
+import { mockAuth, mockShipments, blockTelemetry } from "./helpers/intercept";
+
+test.beforeEach(async ({ page }) => {
+  await blockTelemetry(page);
+  await mockAuth(page);
+});
+
+test.describe("Authentication", () => {
+  test("login with valid credentials redirects to dashboard", async ({
+    page,
+  }) => {
+    await mockShipments(page);
+    await page.goto("/login");
+
+    await page.fill("#email", "admin@navin.com");
+    await page.fill("#password", "password123");
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL("/dashboard");
+  });
+
+  test("login with invalid credentials shows error message", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+
+    await page.fill("#email", "wrong@example.com");
+    await page.fill("#password", "badpassword");
+    await page.click('button[type="submit"]');
+
+    const alert = page
+      .getByRole("alert")
+      .filter({ hasText: /invalid email or password/i });
+    await expect(alert).toBeVisible();
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("login form shows field-level validation errors", async ({ page }) => {
+    await page.goto("/login");
+
+    // Submit with empty fields
+    await page.click('button[type="submit"]');
+
+    await expect(page.getByText("Email is required")).toBeVisible();
+    await expect(page.getByText("Password is required")).toBeVisible();
+  });
+
+  test("login form validates email format", async ({ page }) => {
+    await page.goto("/login");
+
+    await page.fill("#email", "not-an-email");
+    await page.locator("#email").blur();
+
+    await expect(page.getByText("Invalid email format")).toBeVisible();
+  });
+
+  test("logout redirects to landing page", async ({ page }) => {
+    await mockShipments(page);
+    await gotoProtected(page, "/dashboard");
+
+    // Trigger logout via the API mock (simulate removing token directly)
+    await logout(page);
+    await page.goto("/");
+
+    await expect(page).toHaveURL("/");
+  });
+
+  test("accessing /dashboard unauthenticated redirects to login", async ({
+    page,
+  }) => {
+    // Ensure no token is set
+    await page.goto("/login");
+    await page.evaluate(() => localStorage.removeItem("authToken"));
+
+    await page.goto("/dashboard");
+
+    // Allow the 150ms auth check delay
+    await expect(page).toHaveURL(/\/login/, { timeout: 3000 });
+  });
+
+  test("protected routes are inaccessible after logout", async ({ page }) => {
+    await gotoProtected(page, "/dashboard");
+    await logout(page);
+    await page.goto("/dashboard/shipments");
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 3000 });
+  });
+
+  test("previously saved location is restored after login", async ({
+    page,
+  }) => {
+    await mockShipments(page);
+
+    // Try to visit a protected page without auth
+    await page.goto("/login");
+    await page.evaluate(() => localStorage.removeItem("authToken"));
+    await page.goto("/dashboard/shipments");
+
+    // Should be on login
+    await expect(page).toHaveURL(/\/login/);
+
+    // Now log in
+    await page.fill("#email", "admin@navin.com");
+    await page.fill("#password", "password123");
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL("/dashboard/shipments");
+  });
+
+  test("auth check loading spinner renders then resolves", async ({ page }) => {
+    await mockShipments(page);
+
+    // Set token before navigating so auth resolves successfully
+    await page.goto("/login");
+    await loginAs(page, COMPANY_TOKEN);
+    await page.goto("/dashboard");
+
+    // Dashboard should load (spinner resolves within 150ms)
+    await expect(page.getByRole("main")).toBeVisible({ timeout: 2000 });
+  });
+});

--- a/e2e/fixtures/auth.json
+++ b/e2e/fixtures/auth.json
@@ -1,0 +1,27 @@
+{
+  "loginSuccess": {
+    "data": {
+      "user": {
+        "id": "user-001",
+        "email": "admin@navin.com",
+        "name": "Admin User",
+        "role": "admin"
+      },
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTAwMSIsInJvbGUiOiJhZG1pbiIsImlhdCI6MTc1MDg0MDAwMH0.fake_signature_for_e2e_testing_only"
+    }
+  },
+  "loginError": {
+    "message": "Invalid email or password"
+  },
+  "customerLoginSuccess": {
+    "data": {
+      "user": {
+        "id": "user-002",
+        "email": "customer@example.com",
+        "name": "Customer User",
+        "role": "customer"
+      },
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTAwMiIsInJvbGUiOiJjdXN0b21lciIsImlhdCI6MTc1MDg0MDAwMH0.fake_customer_signature_for_e2e"
+    }
+  }
+}

--- a/e2e/fixtures/ledger.json
+++ b/e2e/fixtures/ledger.json
@@ -1,0 +1,56 @@
+{
+  "page1": {
+    "data": [
+      {
+        "blockNumber": 100,
+        "timestamp": "2026-01-10T10:00:00Z",
+        "shipmentId": "ship-001",
+        "shipmentReference": "NV-001",
+        "milestoneEvent": "SHIPMENT_CREATED",
+        "transactionHash": "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aa",
+        "ledger": 50000,
+        "verified": true
+      },
+      {
+        "blockNumber": 101,
+        "timestamp": "2026-01-11T08:00:00Z",
+        "shipmentId": "ship-001",
+        "shipmentReference": "NV-001",
+        "milestoneEvent": "IN_TRANSIT",
+        "transactionHash": "bbccddee22334455bbccddee22334455bbccddee22334455bbccddee22334455bb",
+        "ledger": 50010,
+        "verified": true
+      },
+      {
+        "blockNumber": 102,
+        "timestamp": "2026-01-12T14:00:00Z",
+        "shipmentId": "ship-002",
+        "shipmentReference": "NV-002",
+        "milestoneEvent": "DELIVERED",
+        "transactionHash": "ccddeeff33445566ccddeeff33445566ccddeeff33445566ccddeeff33445566cc",
+        "ledger": 50020,
+        "verified": true
+      }
+    ],
+    "nextCursor": "cursor-page-2",
+    "hasMore": true,
+    "total": 10
+  },
+  "page2": {
+    "data": [
+      {
+        "blockNumber": 103,
+        "timestamp": "2026-01-13T09:00:00Z",
+        "shipmentId": "ship-003",
+        "shipmentReference": "NV-003",
+        "milestoneEvent": "SETTLEMENT_COMPLETED",
+        "transactionHash": "ddeeff0044556677ddeeff0044556677ddeeff0044556677ddeeff0044556677dd",
+        "ledger": 50030,
+        "verified": false
+      }
+    ],
+    "nextCursor": null,
+    "hasMore": false,
+    "total": 10
+  }
+}

--- a/e2e/fixtures/settlements.json
+++ b/e2e/fixtures/settlements.json
@@ -1,0 +1,78 @@
+{
+  "list": {
+    "data": [
+      {
+        "_id": "stl-001",
+        "id": "stl-001",
+        "shipmentId": "ship-001",
+        "amount": 1500,
+        "token": "XLM",
+        "status": "ESCROWED",
+        "stellarTxHash": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+        "createdAt": "2026-01-10T12:00:00Z",
+        "updatedAt": "2026-01-10T12:00:00Z"
+      },
+      {
+        "_id": "stl-002",
+        "id": "stl-002",
+        "shipmentId": "ship-002",
+        "amount": 850,
+        "token": "XLM",
+        "status": "RELEASED",
+        "stellarTxHash": "bbbbbb2222222222bbbbbb2222222222bbbbbb2222222222bbbbbb2222222222bb",
+        "createdAt": "2026-01-08T09:00:00Z",
+        "updatedAt": "2026-01-09T11:00:00Z",
+        "escrowRelease": {
+          "conditionDescription": "Delivery confirmed on-chain",
+          "releasedAt": "2026-01-09T11:00:00Z",
+          "releasedBy": "system"
+        }
+      },
+      {
+        "_id": "stl-003",
+        "id": "stl-003",
+        "shipmentId": "ship-003",
+        "amount": 500,
+        "token": "USDC",
+        "status": "PENDING",
+        "createdAt": "2026-01-12T15:00:00Z",
+        "updatedAt": "2026-01-12T15:00:00Z"
+      },
+      {
+        "_id": "stl-004",
+        "id": "stl-004",
+        "shipmentId": "ship-004",
+        "amount": 2200,
+        "token": "XLM",
+        "status": "DISPUTED",
+        "createdAt": "2026-01-11T10:00:00Z",
+        "updatedAt": "2026-01-13T08:00:00Z",
+        "escrowRelease": {
+          "disputeReason": "Delivery proof rejected by recipient",
+          "disputedAt": "2026-01-13T08:00:00Z"
+        }
+      }
+    ],
+    "total": 4,
+    "page": 1,
+    "limit": 10
+  },
+  "single": {
+    "settlement": {
+      "_id": "stl-001",
+      "id": "stl-001",
+      "shipmentId": "ship-001",
+      "amount": 1500,
+      "token": "XLM",
+      "status": "ESCROWED",
+      "payerAddress": "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+      "payeeAddress": "GCFXHS4GXL6BVUCXBWXGTITROWLVYXQKQLF4YH5O5JT3YZXCYPAFBJZB",
+      "stellarTxHash": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+      "createdAt": "2026-01-10T12:00:00Z",
+      "updatedAt": "2026-01-10T12:00:00Z",
+      "escrowRelease": {
+        "conditionDescription": "Release upon confirmed delivery"
+      }
+    }
+  }
+}

--- a/e2e/fixtures/shipments.json
+++ b/e2e/fixtures/shipments.json
@@ -1,0 +1,101 @@
+{
+  "list": {
+    "data": [
+      {
+        "id": "ship-001",
+        "_id": "ship-001",
+        "trackingNumber": "NV-001",
+        "origin": "New York, NY",
+        "destination": "Los Angeles, CA",
+        "status": "IN_TRANSIT",
+        "enterpriseId": "ent-1",
+        "logisticsId": "log-1",
+        "milestones": [
+          { "name": "SHIPMENT_CREATED", "timestamp": "2026-01-01T10:00:00Z" },
+          { "name": "IN_TRANSIT", "timestamp": "2026-01-02T08:00:00Z" }
+        ],
+        "createdAt": "2026-01-01T10:00:00Z",
+        "updatedAt": "2026-01-02T08:00:00Z"
+      },
+      {
+        "id": "ship-002",
+        "_id": "ship-002",
+        "trackingNumber": "NV-002",
+        "origin": "Chicago, IL",
+        "destination": "Houston, TX",
+        "status": "DELIVERED",
+        "enterpriseId": "ent-1",
+        "logisticsId": "log-1",
+        "milestones": [
+          { "name": "SHIPMENT_CREATED", "timestamp": "2026-01-03T09:00:00Z" },
+          { "name": "DELIVERED", "timestamp": "2026-01-05T14:00:00Z" }
+        ],
+        "createdAt": "2026-01-03T09:00:00Z",
+        "updatedAt": "2026-01-05T14:00:00Z"
+      },
+      {
+        "id": "ship-003",
+        "_id": "ship-003",
+        "trackingNumber": "NV-003",
+        "origin": "Seattle, WA",
+        "destination": "Miami, FL",
+        "status": "CREATED",
+        "enterpriseId": "ent-1",
+        "logisticsId": "log-1",
+        "milestones": [
+          { "name": "SHIPMENT_CREATED", "timestamp": "2026-01-06T11:00:00Z" }
+        ],
+        "createdAt": "2026-01-06T11:00:00Z",
+        "updatedAt": "2026-01-06T11:00:00Z"
+      }
+    ],
+    "meta": {
+      "page": 1,
+      "limit": 5,
+      "total": 3,
+      "nextCursor": null,
+      "hasMore": false
+    }
+  },
+  "single": {
+    "data": {
+      "id": "ship-001",
+      "_id": "ship-001",
+      "trackingNumber": "NV-001",
+      "origin": "New York, NY",
+      "destination": "Los Angeles, CA",
+      "status": "IN_TRANSIT",
+      "enterpriseId": "ent-1",
+      "logisticsId": "log-1",
+      "milestones": [
+        {
+          "name": "SHIPMENT_CREATED",
+          "timestamp": "2026-01-01T10:00:00Z",
+          "description": "Shipment registered on chain"
+        },
+        {
+          "name": "IN_TRANSIT",
+          "timestamp": "2026-01-02T08:00:00Z",
+          "description": "Departed origin facility"
+        }
+      ],
+      "createdAt": "2026-01-01T10:00:00Z",
+      "updatedAt": "2026-01-02T08:00:00Z"
+    }
+  },
+  "created": {
+    "data": {
+      "id": "ship-new",
+      "_id": "ship-new",
+      "trackingNumber": "NV-999",
+      "origin": "Boston, MA",
+      "destination": "Denver, CO",
+      "status": "CREATED",
+      "enterpriseId": "",
+      "logisticsId": "",
+      "milestones": [],
+      "createdAt": "2026-06-25T12:00:00Z",
+      "updatedAt": "2026-06-25T12:00:00Z"
+    }
+  }
+}

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,46 @@
+import type { Page } from "@playwright/test";
+
+/** A structurally valid JWT that passes the `isValidJWT` check in authInterceptor.ts */
+export const COMPANY_TOKEN =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTAwMSIsInJvbGUiOiJhZG1pbiIsImlhdCI6MTc1MDg0MDAwMH0.fake_signature_for_e2e_testing_only";
+
+export const CUSTOMER_TOKEN =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTAwMiIsInJvbGUiOiJjdXN0b21lciIsImlhdCI6MTc1MDg0MDAwMH0.fake_customer_signature_for_e2e";
+
+/**
+ * Sets the authToken in localStorage so the app treats the user as authenticated.
+ * Call this before navigating to any protected route to skip the login UI.
+ *
+ * Must be called after page.goto() or inside a storageState fixture, because
+ * localStorage is scoped to an origin and requires a page context.
+ */
+export async function loginAs(
+  page: Page,
+  token = COMPANY_TOKEN,
+): Promise<void> {
+  await page.evaluate((t) => {
+    localStorage.setItem("authToken", t);
+  }, token);
+}
+
+/**
+ * Navigate to a protected route with the auth token already in localStorage.
+ * Combines goto + loginAs + a second goto so the app sees the token on load.
+ */
+export async function gotoProtected(
+  page: Page,
+  path: string,
+  token = COMPANY_TOKEN,
+): Promise<void> {
+  // Prime the origin so we can write to localStorage
+  await page.goto("/login");
+  await loginAs(page, token);
+  await page.goto(path);
+}
+
+/** Clears auth state from localStorage */
+export async function logout(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    localStorage.removeItem("authToken");
+  });
+}

--- a/e2e/helpers/intercept.ts
+++ b/e2e/helpers/intercept.ts
@@ -1,0 +1,100 @@
+import type { Page, Route } from "@playwright/test";
+import shipmentsFixture from "../fixtures/shipments.json";
+import settlementsFixture from "../fixtures/settlements.json";
+import ledgerFixture from "../fixtures/ledger.json";
+import authFixture from "../fixtures/auth.json";
+
+type JsonValue = Record<string, unknown> | unknown[];
+
+async function respondJson(
+  route: Route,
+  body: JsonValue,
+  status = 200,
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+/** Intercepts all /api/shipments requests with fixture data */
+export async function mockShipments(page: Page): Promise<void> {
+  await page.route("**/api/shipments", async (route) => {
+    const url = new URL(route.request().url());
+    const status = url.searchParams.get("status");
+    if (status) {
+      const filtered = {
+        ...shipmentsFixture.list,
+        data: shipmentsFixture.list.data.filter((s) => s.status === status),
+      };
+      await respondJson(route, filtered);
+    } else {
+      await respondJson(route, shipmentsFixture.list);
+    }
+  });
+
+  await page.route("**/api/shipments/ship-001", async (route) => {
+    await respondJson(route, shipmentsFixture.single);
+  });
+
+  await page.route("**/api/shipments", async (route) => {
+    if (route.request().method() === "POST") {
+      await respondJson(route, shipmentsFixture.created, 201);
+    }
+  });
+}
+
+/** Intercepts all /api/settlements requests with fixture data */
+export async function mockSettlements(page: Page): Promise<void> {
+  await page.route("**/api/settlements", async (route) => {
+    await respondJson(route, settlementsFixture.list);
+  });
+
+  await page.route("**/api/settlements/stl-001", async (route) => {
+    await respondJson(route, settlementsFixture.single);
+  });
+}
+
+/** Intercepts /api/ledger/blocks requests with fixture data */
+export async function mockLedger(page: Page): Promise<void> {
+  await page.route("**/api/ledger/blocks*", async (route) => {
+    const url = new URL(route.request().url());
+    const cursor = url.searchParams.get("cursor");
+    if (cursor === "cursor-page-2") {
+      await respondJson(route, ledgerFixture.page2);
+    } else {
+      await respondJson(route, ledgerFixture.page1);
+    }
+  });
+}
+
+/** Intercepts /api/auth/* requests */
+export async function mockAuth(page: Page): Promise<void> {
+  await page.route("**/api/auth/login", async (route) => {
+    const body = JSON.parse(route.request().postData() ?? "{}") as {
+      email?: string;
+    };
+    if (body.email === "admin@navin.com") {
+      await respondJson(route, authFixture.loginSuccess);
+    } else {
+      await respondJson(route, authFixture.loginError, 401);
+    }
+  });
+
+  await page.route("**/api/auth/logout", async (route) => {
+    await respondJson(route, { data: {} });
+  });
+
+  await page.route("**/api/auth/refresh", async (route) => {
+    await respondJson(route, {
+      data: { token: authFixture.loginSuccess.data.token },
+    });
+  });
+}
+
+/** Blocks Sentry requests to avoid noise in tests */
+export async function blockTelemetry(page: Page): Promise<void> {
+  await page.route("**sentry.io/**", (route) => route.abort());
+  await page.route("**ingest.sentry.io/**", (route) => route.abort());
+}

--- a/e2e/ledger.spec.ts
+++ b/e2e/ledger.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from "@playwright/test";
+import { gotoProtected } from "./helpers/auth";
+import { mockLedger, mockAuth, blockTelemetry } from "./helpers/intercept";
+import ledgerFixture from "./fixtures/ledger.json";
+
+test.beforeEach(async ({ page }) => {
+  await blockTelemetry(page);
+  await mockAuth(page);
+  await mockLedger(page);
+});
+
+test.describe("Blockchain Ledger", () => {
+  test("ledger table loads and renders block rows", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    // Table should be present
+    await expect(
+      page.getByRole("table", { name: /blockchain ledger/i }),
+    ).toBeVisible();
+
+    // First page blocks should be visible
+    for (const block of ledgerFixture.page1.data) {
+      await expect(page.getByText(block.shipmentReference)).toBeVisible();
+    }
+  });
+
+  test("block number is displayed with # prefix", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(page.getByText("#100")).toBeVisible();
+    await expect(page.getByText("#101")).toBeVisible();
+  });
+
+  test("milestone event badges are displayed", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(page.getByText("Shipment Created")).toBeVisible();
+    await expect(page.getByText("In Transit")).toBeVisible();
+    await expect(page.getByText("Delivered")).toBeVisible();
+  });
+
+  test('verified blocks show "Verified" status', async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(page.getByText("Verified").first()).toBeVisible();
+  });
+
+  test("transaction hash is truncated in the table", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    const hash = ledgerFixture.page1.data[0].transactionHash;
+    const truncated = `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+
+    // The full hash should NOT be visible as plain text
+    await expect(page.getByText(hash)).not.toBeVisible();
+    // The truncated version should be visible inside a link
+    await expect(page.getByText(truncated)).toBeVisible();
+  });
+
+  test("transaction hash links open Stellar Expert in a new tab", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    const hash = ledgerFixture.page1.data[0].transactionHash;
+    const txLink = page.locator(`a[href*="${hash}"]`).first();
+    await expect(txLink).toBeVisible();
+    await expect(txLink).toHaveAttribute("target", "_blank");
+    await expect(txLink).toHaveAttribute(
+      "href",
+      new RegExp("stellar\\.expert"),
+    );
+  });
+
+  test('"Next" button fetches the next cursor page', async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    // Wait for first page to load
+    await expect(page.getByText("#100")).toBeVisible();
+
+    // Click next page
+    await page.getByRole("button", { name: /load next page|^next$/i }).click();
+
+    // Second page block should appear
+    await expect(page.getByText("#103")).toBeVisible();
+    await expect(page.getByText("Settlement Completed")).toBeVisible();
+  });
+
+  test('"Previous" button is disabled on the first page', async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(
+      page.getByRole("button", { name: /previous page|^previous$/i }),
+    ).toBeDisabled();
+  });
+
+  test('"Previous" button navigates back to page 1', async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(page.getByText("#100")).toBeVisible();
+    await page.getByRole("button", { name: /load next page|^next$/i }).click();
+    await expect(page.getByText("#103")).toBeVisible();
+
+    await page
+      .getByRole("button", { name: /previous page|^previous$/i })
+      .click();
+    await expect(page.getByText("#100")).toBeVisible();
+  });
+
+  test("filter by milestone event resets to page 1", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    // Navigate to page 2 first
+    await expect(page.getByText("#100")).toBeVisible();
+    await page.getByRole("button", { name: /load next page|^next$/i }).click();
+    await expect(page.getByText("#103")).toBeVisible();
+
+    // Apply a filter — should reset pagination and re-fetch
+    await page.click("#ledger-filter-delivered");
+
+    // Page indicator should show page 1
+    await expect(page.getByText(/page 1/i)).toBeVisible();
+  });
+
+  test("filter buttons render for all milestone event types", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(
+      page.getByRole("button", { name: "All Events" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "In Transit" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Delivered" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Settlement Completed" }),
+    ).toBeVisible();
+  });
+
+  test("refresh button triggers a new API fetch", async ({ page }) => {
+    let fetchCount = 0;
+    await page.route("**/api/ledger/blocks*", async (route) => {
+      fetchCount++;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(ledgerFixture.page1),
+      });
+    });
+
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+    await expect(page.getByText("#100")).toBeVisible();
+
+    const beforeCount = fetchCount;
+    await page.click("#ledger-refresh-btn");
+    await page.waitForTimeout(200);
+
+    expect(fetchCount).toBeGreaterThan(beforeCount);
+  });
+
+  test("total blocks count is displayed in stats bar", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    // ledgerFixture.page1.total = 10
+    await expect(page.getByText("10")).toBeVisible();
+  });
+
+  test("network label shows Stellar Mainnet", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(page.getByText("Stellar Mainnet")).toBeVisible();
+  });
+
+  test("error banner renders when API fails", async ({ page }) => {
+    await page.route("**/api/ledger/blocks*", async (route) => {
+      await route.fulfill({ status: 500, body: "Internal Server Error" });
+    });
+
+    await gotoProtected(page, "/dashboard/blockchain-ledger");
+
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 3000 });
+    await expect(
+      page.getByText(/failed to load blockchain ledger/i),
+    ).toBeVisible();
+  });
+});

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "@playwright/test";
+import { gotoProtected } from "./helpers/auth";
+import { mockAuth, blockTelemetry } from "./helpers/intercept";
+
+test.beforeEach(async ({ page }) => {
+  await blockTelemetry(page);
+  await mockAuth(page);
+});
+
+// Notifications are static local state — no API mock needed
+
+test.describe("Notifications", () => {
+  test("notifications page renders the list", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await expect(
+      page.getByRole("heading", { name: /notifications/i }),
+    ).toBeVisible();
+    // At least one notification card should be present
+    await expect(page.getByText("Shipment Arrived at Port")).toBeVisible();
+  });
+
+  test("unread notifications have an unread indicator dot", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    // Unread items show a blue dot (w-2 h-2 bg-[#3b82f6] rounded-full)
+    // Verify unread notifications are present in the "TODAY" section
+    await expect(page.getByText("TODAY")).toBeVisible();
+    await expect(page.getByText("Shipment Arrived at Port")).toBeVisible();
+  });
+
+  test("read notifications are rendered in the EARLIER section", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await expect(page.getByText("EARLIER")).toBeVisible();
+    await expect(page.getByText("Customs Clearance Completed")).toBeVisible();
+  });
+
+  test("clicking a notification marks it as read", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    // The "mark as read" check button is only shown on unread notifications
+    const checkBtn = page
+      .getByRole("button", { name: /mark as read/i })
+      .first();
+    await expect(checkBtn).toBeVisible();
+
+    await checkBtn.click();
+
+    // After marking, that particular card should no longer show the check button
+    // (it moves to read state — the number of unread mark buttons decreases)
+    const remainingCheckBtns = page.getByRole("button", {
+      name: /mark as read/i,
+    });
+    const count = await remainingCheckBtns.count();
+    expect(count).toBeLessThanOrEqual(5); // started with 6 unread
+  });
+
+  test('"Mark all as read" button clears all unread indicators', async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await page.getByRole("button", { name: /mark all as read/i }).click();
+
+    // After marking all read, no "mark as read" check buttons should be visible
+    await expect(
+      page.getByRole("button", { name: /mark as read/i }),
+    ).toHaveCount(0);
+
+    // TODAY section should be gone (no unread left)
+    await expect(page.getByText("TODAY")).not.toBeVisible();
+  });
+
+  test("filter by Shipments tab shows only shipment notifications", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await page.getByRole("button", { name: /^shipments/i }).click();
+
+    // Shipment notifications should be visible
+    await expect(page.getByText("Shipment Arrived at Port")).toBeVisible();
+
+    // Settlement-only notification should not be visible
+    await expect(page.getByText("Smart Contract Executed")).not.toBeVisible();
+  });
+
+  test("filter by Settlements tab shows only settlement notifications", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await page.getByRole("button", { name: /^settlements/i }).click();
+
+    await expect(page.getByText("Smart Contract Executed")).toBeVisible();
+    await expect(page.getByText("Shipment Arrived at Port")).not.toBeVisible();
+  });
+
+  test("filter by System tab shows only system notifications", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await page.getByRole("button", { name: /^system/i }).click();
+
+    await expect(page.getByText("Security Alert")).toBeVisible();
+    await expect(page.getByText("System Maintenance Scheduled")).toBeVisible();
+    await expect(page.getByText("Shipment Arrived at Port")).not.toBeVisible();
+  });
+
+  test("All tab restores full notification list", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    // Switch to system, then back to all
+    await page.getByRole("button", { name: /^system/i }).click();
+    await expect(page.getByText("Shipment Arrived at Port")).not.toBeVisible();
+
+    await page.getByRole("button", { name: /^all/i }).click();
+    await expect(page.getByText("Shipment Arrived at Port")).toBeVisible();
+  });
+
+  test("search filters notifications by title keyword", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    const searchInput = page.getByPlaceholder(
+      /search by id, contract, or keyword/i,
+    );
+    await searchInput.fill("security");
+
+    await expect(page.getByText("Security Alert")).toBeVisible();
+    await expect(page.getByText("Shipment Arrived at Port")).not.toBeVisible();
+  });
+
+  test("search filters notifications by badge content", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    const searchInput = page.getByPlaceholder(
+      /search by id, contract, or keyword/i,
+    );
+    await searchInput.fill("NV-9920");
+
+    await expect(page.getByText("Shipment Arrived at Port")).toBeVisible();
+    await expect(page.getByText("Smart Contract Executed")).not.toBeVisible();
+  });
+
+  test('empty search result shows "no notifications found" message', async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    const searchInput = page.getByPlaceholder(
+      /search by id, contract, or keyword/i,
+    );
+    await searchInput.fill("zzznomatch999");
+
+    await expect(page.getByText(/no notifications found/i)).toBeVisible();
+    await expect(
+      page.getByText(/try adjusting your search terms/i),
+    ).toBeVisible();
+  });
+
+  test("filter count badges show correct totals", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    // The "All" tab badge should show 16 (total notifications in local state)
+    const allBtn = page.getByRole("button", { name: /^all/i });
+    await expect(allBtn).toContainText("16");
+  });
+
+  test("pagination renders when list exceeds items per page", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    // 16 notifications with 10 per page → pagination should appear
+    await expect(page.getByRole("button", { name: /previous/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /next/i })).toBeVisible();
+    await expect(page.getByText(/page 1 of 2/i)).toBeVisible();
+  });
+
+  test("next page button navigates to page 2", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await page.getByRole("button", { name: /^next$/i }).click();
+
+    await expect(page.getByText(/page 2 of 2/i)).toBeVisible();
+    // Page 2 notification
+    await expect(page.getByText("Delivery Delayed")).toBeVisible();
+  });
+
+  test("previous page button is disabled on page 1", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/notifications");
+
+    await expect(
+      page.getByRole("button", { name: /^previous$/i }),
+    ).toBeDisabled();
+  });
+});

--- a/e2e/settlements.spec.ts
+++ b/e2e/settlements.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from "@playwright/test";
+import { gotoProtected } from "./helpers/auth";
+import { mockSettlements, mockAuth, blockTelemetry } from "./helpers/intercept";
+import settlementsFixture from "./fixtures/settlements.json";
+
+test.beforeEach(async ({ page }) => {
+  await blockTelemetry(page);
+  await mockAuth(page);
+  await mockSettlements(page);
+});
+
+test.describe("Settlements", () => {
+  test("settlements list renders with correct rows", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    for (const settlement of settlementsFixture.list.data) {
+      await expect(page.getByText(settlement.shipmentId)).toBeVisible();
+    }
+  });
+
+  test("status badges display correct labels", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    await expect(page.getByText("ESCROWED")).toBeVisible();
+    await expect(page.getByText("RELEASED")).toBeVisible();
+    await expect(page.getByText("PENDING")).toBeVisible();
+    await expect(page.getByText("DISPUTED")).toBeVisible();
+  });
+
+  test("summary cards show totals", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    // Summary cards
+    await expect(page.getByText(/total settled/i)).toBeVisible();
+    await expect(page.getByText(/total records/i)).toBeVisible();
+  });
+
+  test("clicking a settlement row opens the Payment Detail Modal", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    // Click first settlement row (stl-001 / ship-001)
+    await page.getByRole("row").filter({ hasText: "ship-001" }).click();
+
+    // Modal should appear with settlement data
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 3000 });
+  });
+
+  test("Payment Detail Modal shows shipment ID", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    await page.getByRole("row").filter({ hasText: "ship-001" }).click();
+
+    const modal = page.getByRole("dialog");
+    await expect(modal).toBeVisible({ timeout: 3000 });
+    await expect(modal.getByText("ship-001")).toBeVisible();
+  });
+
+  test("Payment Detail Modal can be closed", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    await page.getByRole("row").filter({ hasText: "ship-001" }).click();
+
+    const modal = page.getByRole("dialog");
+    await expect(modal).toBeVisible({ timeout: 3000 });
+
+    // Close via the close button (typical aria-label or role=button)
+    await page.keyboard.press("Escape");
+    await expect(modal).not.toBeVisible({ timeout: 2000 });
+  });
+
+  test("filter by settlement status — RELEASED only", async ({ page }) => {
+    // Override to return only RELEASED settlements when filtered
+    await page.route("**/api/settlements*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("status") === "RELEASED") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ...settlementsFixture.list,
+            data: settlementsFixture.list.data.filter(
+              (s) => s.status === "RELEASED",
+            ),
+            total: 1,
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await gotoProtected(page, "/dashboard/settlements");
+
+    const statusFilter = page.getByLabel("Filter by settlement status");
+    await statusFilter.selectOption("RELEASED");
+
+    // Only the RELEASED row should be present
+    await expect(page.getByText("ship-002")).toBeVisible();
+    await expect(page.getByText("ship-001")).not.toBeVisible();
+  });
+
+  test("sort toggle button changes sort order label", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/settlements");
+
+    const sortBtn = page.getByLabel(/sort by date/i);
+    await expect(sortBtn).toBeVisible();
+
+    // Initial state should show "Newest"
+    await expect(sortBtn).toContainText(/newest/i);
+
+    await sortBtn.click();
+
+    await expect(sortBtn).toContainText(/oldest/i);
+  });
+
+  test("pagination controls are present when there are multiple pages", async ({
+    page,
+  }) => {
+    // Return more than one page of results
+    await page.route("**/api/settlements*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ...settlementsFixture.list,
+          total: 25,
+        }),
+      });
+    });
+
+    await gotoProtected(page, "/dashboard/settlements");
+
+    await expect(
+      page.getByRole("button", { name: /previous page/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /next page/i }),
+    ).toBeVisible();
+  });
+
+  test("previous page button is disabled on page 1", async ({ page }) => {
+    await page.route("**/api/settlements*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...settlementsFixture.list, total: 25 }),
+      });
+    });
+
+    await gotoProtected(page, "/dashboard/settlements");
+
+    await expect(
+      page.getByRole("button", { name: /previous page/i }),
+    ).toBeDisabled();
+  });
+
+  test("next page button navigates to page 2", async ({ page }) => {
+    const page2Data = {
+      data: [
+        {
+          ...settlementsFixture.list.data[0],
+          _id: "stl-005",
+          id: "stl-005",
+          shipmentId: "ship-005",
+        },
+      ],
+      total: 25,
+      page: 2,
+      limit: 10,
+    };
+
+    let callCount = 0;
+    await page.route("**/api/settlements*", async (route) => {
+      callCount++;
+      if (callCount > 1) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(page2Data),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ...settlementsFixture.list, total: 25 }),
+        });
+      }
+    });
+
+    await gotoProtected(page, "/dashboard/settlements");
+
+    await page.getByRole("button", { name: "2" }).click();
+
+    await expect(page.getByText("ship-005")).toBeVisible();
+  });
+});

--- a/e2e/shipments-company.spec.ts
+++ b/e2e/shipments-company.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "@playwright/test";
+import { gotoProtected } from "./helpers/auth";
+import { mockShipments, mockAuth, blockTelemetry } from "./helpers/intercept";
+import shipmentsFixture from "./fixtures/shipments.json";
+
+test.beforeEach(async ({ page }) => {
+  await blockTelemetry(page);
+  await mockAuth(page);
+  await mockShipments(page);
+});
+
+test.describe("Shipments — Company view", () => {
+  test("shipments list renders with rows from API", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments");
+
+    // All three fixture shipments should appear in the table
+    for (const shipment of shipmentsFixture.list.data) {
+      await expect(page.getByText(shipment.id)).toBeVisible();
+    }
+  });
+
+  test("pagination summary is displayed", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments");
+
+    await expect(page.getByText(/showing/i)).toBeVisible();
+  });
+
+  test("previous page button is disabled on first page", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments");
+
+    const prevBtn = page.getByRole("button", { name: /prev/i });
+    await expect(prevBtn).toBeDisabled();
+  });
+
+  test("filter shipments by status — IN_TRANSIT", async ({ page }) => {
+    // Override the route to return only IN_TRANSIT shipments
+    await page.route("**/api/shipments*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("status") === "IN_TRANSIT") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ...shipmentsFixture.list,
+            data: shipmentsFixture.list.data.filter(
+              (s) => s.status === "IN_TRANSIT",
+            ),
+          }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await gotoProtected(page, "/dashboard/shipments?status=IN_TRANSIT");
+
+    await expect(page.getByText("ship-001")).toBeVisible();
+    await expect(page.getByText("ship-002")).not.toBeVisible();
+  });
+
+  test("shipment row shows origin, destination, and status badge", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/shipments");
+
+    const firstShipment = shipmentsFixture.list.data[0];
+    await expect(page.getByText(firstShipment.origin)).toBeVisible();
+    await expect(page.getByText(firstShipment.destination)).toBeVisible();
+    await expect(page.getByText(firstShipment.status)).toBeVisible();
+  });
+
+  test("open shipment detail renders all key sections", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments/ship-001");
+
+    // ShipmentDetailHeader — shows shipment id
+    await expect(page.getByText(/#SHP-992834/i)).toBeVisible();
+    // Status badge
+    await expect(page.getByText(/IN_TRANSIT/i)).toBeVisible();
+    // Milestone timeline section should render
+    await expect(
+      page.locator('main, [class*="shipment-detail"]').first(),
+    ).toBeVisible();
+  });
+
+  test("create shipment form renders all required fields", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments/create");
+
+    await expect(page.locator("#origin")).toBeVisible();
+    await expect(page.locator("#destination")).toBeVisible();
+    await expect(page.locator("#itemDescription")).toBeVisible();
+    await expect(page.locator("#weight")).toBeVisible();
+    await expect(page.locator("#recipientName")).toBeVisible();
+    await expect(page.locator("#recipientContact")).toBeVisible();
+    await expect(page.locator("#expectedDeliveryDate")).toBeVisible();
+  });
+
+  test("create shipment form shows validation errors when submitted empty", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/shipments/create");
+
+    await page.click('button[type="submit"]');
+
+    await expect(page.getByText("Origin address is required")).toBeVisible();
+    await expect(
+      page.getByText("Destination address is required"),
+    ).toBeVisible();
+    await expect(page.getByText("Item description is required")).toBeVisible();
+    await expect(page.getByText("Recipient name is required")).toBeVisible();
+  });
+
+  test("create shipment submits and shows success screen", async ({ page }) => {
+    await page.route("**/api/shipments", async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(shipmentsFixture.created),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await gotoProtected(page, "/dashboard/shipments/create");
+
+    await page.fill("#origin", "Boston, MA");
+    await page.fill("#destination", "Denver, CO");
+    await page.fill("#itemDescription", "Electronics components");
+    await page.fill("#weight", "5.5");
+    await page.fill("#recipientName", "Jane Doe");
+    await page.fill("#recipientContact", "jane@example.com");
+    await page.fill("#expectedDeliveryDate", "2026-07-15");
+
+    await page.click('button[type="submit"]');
+
+    await expect(
+      page.getByText(/shipment created successfully/i),
+    ).toBeVisible();
+    await expect(page.getByText("ship-new")).toBeVisible();
+  });
+
+  test("create another button resets the form after success", async ({
+    page,
+  }) => {
+    await page.route("**/api/shipments", async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(shipmentsFixture.created),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await gotoProtected(page, "/dashboard/shipments/create");
+
+    await page.fill("#origin", "Boston, MA");
+    await page.fill("#destination", "Denver, CO");
+    await page.fill("#itemDescription", "Test goods");
+    await page.fill("#weight", "2");
+    await page.fill("#recipientName", "John");
+    await page.fill("#recipientContact", "555-0100");
+    await page.fill("#expectedDeliveryDate", "2026-07-20");
+    await page.click('button[type="submit"]');
+
+    await expect(
+      page.getByText(/shipment created successfully/i),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /create another/i }).click();
+
+    // Form should be reset
+    await expect(page.locator("#origin")).toHaveValue("");
+  });
+
+  test("back button navigates away from create form", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments/create");
+
+    await page.getByRole("button", { name: /back/i }).click();
+
+    // Should navigate back (not on create page)
+    await expect(page).not.toHaveURL("/dashboard/shipments/create");
+  });
+});

--- a/e2e/shipments-customer.spec.ts
+++ b/e2e/shipments-customer.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { gotoProtected, CUSTOMER_TOKEN } from "./helpers/auth";
+import { mockShipments, mockAuth, blockTelemetry } from "./helpers/intercept";
+import shipmentsFixture from "./fixtures/shipments.json";
+
+test.beforeEach(async ({ page }) => {
+  await blockTelemetry(page);
+  await mockAuth(page);
+  await mockShipments(page);
+});
+
+test.describe("Shipments — Customer view", () => {
+  test("customer can view the shipments list", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments", CUSTOMER_TOKEN);
+
+    // At least one shipment should be visible
+    await expect(
+      page.getByText(shipmentsFixture.list.data[0].id),
+    ).toBeVisible();
+  });
+
+  test("customer can open a shipment detail page", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments/ship-001", CUSTOMER_TOKEN);
+
+    // Page renders — header with shipment info should be present
+    await expect(page.getByText(/#SHP-992834/i)).toBeVisible();
+  });
+
+  test("customer shipment detail shows milestone timeline", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/shipments/ship-001", CUSTOMER_TOKEN);
+
+    // The milestone section should be present on the page
+    const milestoneSection = page
+      .locator('[class*="milestone"], [class*="timeline"]')
+      .first();
+    await expect(milestoneSection).toBeVisible();
+  });
+
+  test('customer cannot see "Create Shipment" link in navigation', async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/shipments", CUSTOMER_TOKEN);
+
+    // The create shipment nav link / button should not be present for customers
+    // (the route exists but the sidebar nav item should be absent or access should redirect)
+    const createLink = page.getByRole("link", { name: /create shipment/i });
+    await expect(createLink).toHaveCount(0);
+  });
+
+  test("customer cannot access the create shipment page directly", async ({
+    page,
+  }) => {
+    // Customer token is set but the create route should either
+    // not show company-specific controls or handle the customer gracefully
+    await gotoProtected(page, "/dashboard/shipments/create", CUSTOMER_TOKEN);
+
+    // Page should load without crashing (React renders within the protected layout)
+    await expect(page.locator("body")).toBeVisible();
+  });
+
+  test("customer shipments list shows correct columns", async ({ page }) => {
+    await gotoProtected(page, "/dashboard/shipments", CUSTOMER_TOKEN);
+
+    await expect(
+      page.getByRole("columnheader", { name: /shipment id/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: /origin/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: /destination/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: /status/i }),
+    ).toBeVisible();
+  });
+
+  test("customer sees delivery status badge on shipment row", async ({
+    page,
+  }) => {
+    await gotoProtected(page, "/dashboard/shipments", CUSTOMER_TOKEN);
+
+    // The DELIVERED status badge should be visible for ship-002
+    await expect(page.getByText("DELIVERED")).toBeVisible();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test --config=../playwright.config.ts",
     "prepare": "husky"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.3
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.2.1
         version: 4.2.1
@@ -493,6 +496,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -1384,6 +1392,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1768,6 +1781,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -2526,6 +2549,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -3409,6 +3436,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3749,6 +3779,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "html" : "list",
+
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm run dev",
+    cwd: "./frontend",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@playwright/test": ["./frontend/node_modules/@playwright/test"]
+    },
+    "typeRoots": ["./frontend/node_modules/@types"]
+  },
+  "include": ["playwright.config.ts", "e2e/**/*.ts"]
+}


### PR DESCRIPTION
- Install @playwright/test and configure playwright.config.ts at repo root
- Add test:e2e script to frontend/package.json
- Add root tsconfig.json scoped to e2e/ and playwright config
- Write 6 test suites: auth, shipments-company, shipments-customer,
  settlements, ledger, notifications
- Add e2e/fixtures/ with JSON mocks for all API endpoints
- Add e2e/helpers/auth.ts (gotoProtected, loginAs, logout helpers)
- Add e2e/helpers/intercept.ts (page.route mocks per fixture)
- Add E2E job to CI workflow with Playwright browser install and artifact upload on failure

closes #246