### PR TITLE
feat: Add Technology and Partners Logo Strip on Landing Page

### DIFF
--- a/frontend/src/LandingPage/sections/LogoStrip/LogoStrip.tsx
+++ b/frontend/src/LandingPage/sections/LogoStrip/LogoStrip.tsx
@@ -1,52 +1,48 @@
 import React from 'react';
 
 const LOGOS = [
-  { name: 'Stellar', color: '#00D4C8' },
-  { name: 'Soroban', color: '#9B5CF7' },
-  { name: 'Shipbob', color: '#00B4D8' },
-  { name: 'FedEx', color: '#FF7439' },
-  { name: 'DHL', color: '#FFC600' },
-  { name: 'Maersk', color: '#4BA8E8' },
+  { name: 'Stellar',  color: '#00D4C8' },
+  { name: 'Soroban',  color: '#9B5CF7' },
+  { name: 'Shipbob',  color: '#00B4D8' },
+  { name: 'FedEx',    color: '#FF7439' },
+  { name: 'DHL',      color: '#FFC600' },
+  { name: 'Maersk',   color: '#4BA8E8' },
   { name: 'Flexport', color: '#00AEEF' },
 ];
 
-// Duplicated for seamless infinite loop
 const STRIP = [...LOGOS, ...LOGOS];
 
 const LogoStrip: React.FC = () => (
-  <div className="w-full py-10 overflow-hidden border-y border-[rgba(0,180,160,0.12)] bg-[rgba(0,8,12,0.4)]">
+  <section
+    aria-label="Technology and Partners"
+    className="w-full py-10 overflow-hidden border-y border-[rgba(0,180,160,0.12)] bg-[rgba(0,8,12,0.4)]"
+  >
     <p className="text-center text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-500 mb-6">
       Powered by &amp; Trusted with
     </p>
 
-    <div
-      className="relative flex w-max gap-10 logo-strip-track"
-      onMouseEnter={(e) =>
-        (e.currentTarget.style.animationPlayState = 'paused')
-      }
-      onMouseLeave={(e) =>
-        (e.currentTarget.style.animationPlayState = 'running')
-      }
-    >
-      {STRIP.map((logo, i) => (
-        <div
-          key={i}
-          className="flex items-center justify-center px-6 min-w-[140px] h-14 rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.03)] select-none shrink-0"
-        >
-          <span
-            className="text-lg font-bold tracking-tight"
-            style={{
-              color: logo.color,
-              fontFamily: "'Bricolage Grotesque', sans-serif",
-              textShadow: `0 0 18px ${logo.color}55`,
-            }}
+    <div className="logo-strip-wrapper">
+      <div className="logo-strip-track">
+        {STRIP.map((logo, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-center px-6 min-w-[140px] h-14 rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.03)] select-none shrink-0"
           >
-            {logo.name}
-          </span>
-        </div>
-      ))}
+            <span
+              className="text-lg font-bold tracking-tight"
+              style={{
+                color: logo.color,
+                fontFamily: "'Bricolage Grotesque', sans-serif",
+                textShadow: `0 0 18px ${logo.color}55`,
+              }}
+            >
+              {logo.name}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
-  </div>
+  </section>
 );
 
 export default LogoStrip;

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -1,34 +1,23 @@
-import React, { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { Menu, X } from "lucide-react";
-import { useScrollSpy } from "../../hooks/useScrollSpy";
-
-const SECTION_IDS = ["hero", "why-navin", "features", "how-it-works", "faq"] as const;
-
-const navLinks = [
-  { id: "hero",         label: "Hero",         href: "#hero" },
-  { id: "why-navin",    label: "Why Navin",    href: "#why-navin" },
-  { id: "features",     label: "Features",     href: "#features" },
-  { id: "how-it-works", label: "How It Works", href: "#how-it-works" },
-  { id: "faq",          label: "FAQ",          href: "#faq" },
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 import { useScrollSpy } from '../../hooks/useScrollSpy';
 
-const NAV_SECTION_IDS = ['about', 'features', 'how-it-works'] as const;
+const SECTION_IDS = ['hero', 'why-navin', 'features', 'how-it-works', 'faq'] as const;
 
 const navLinks = [
-  { id: 'about', label: 'About', href: '#about' },
-  { id: 'features', label: 'Features', href: '#features' },
+  { id: 'hero',         label: 'Hero',         href: '#hero' },
+  { id: 'why-navin',    label: 'Why Navin',    href: '#why-navin' },
+  { id: 'features',     label: 'Features',     href: '#features' },
   { id: 'how-it-works', label: 'How It Works', href: '#how-it-works' },
+  { id: 'faq',          label: 'FAQ',          href: '#faq' },
 ];
 
 const Navbar: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const location = useLocation();
 
-  const isLandingPage = location.pathname === "/";
+  const isLandingPage = location.pathname === '/';
   const activeSectionId = useScrollSpy(
     isLandingPage ? [...SECTION_IDS] : [],
   );
@@ -38,18 +27,12 @@ const Navbar: React.FC = () => {
     sectionId: string,
   ) => {
     setIsMenuOpen(false);
-
     if (isLandingPage) {
       e.preventDefault();
       const element = document.getElementById(sectionId);
       if (element) {
-        element.scrollIntoView({ behavior: "smooth" });
+        element.scrollIntoView({ behavior: 'smooth' });
       }
-  const handleNavClick = (sectionId: string) => {
-    setIsMenuOpen(false);
-    if (location.pathname === '/') {
-      const element = document.getElementById(sectionId);
-      if (element) element.scrollIntoView({ behavior: 'smooth' });
     }
   };
 
@@ -70,38 +53,23 @@ const Navbar: React.FC = () => {
 
         {/* Desktop Menu */}
         <div className="hidden md:flex items-center gap-12">
-          {/* Nav Links */}
           <div className="flex flex-row justify-center items-center px-6 py-3.5 gap-12 h-[55.19px] bg-gradient-card border-t border-[rgba(0,128,128,0.3)] rounded-[30px]">
             {navLinks.map((link) => {
               const isActive = activeSectionId === link.id;
               return (
-                <a
-                  key={link.id}
+                
+                 <a key={link.id}
                   href={link.href}
                   className={`text-white no-underline text-base font-normal relative transition-colors duration-300 cursor-pointer hover:text-[#00d4c8] after:content-[''] after:absolute after:-bottom-1.5 after:left-0 after:w-0 after:h-0.5 after:bg-[#00d4c8] after:transition-all after:duration-300 hover:after:w-full${
-                    isActive ? " !text-[#00d4c8] after:!w-full" : ""
+                    isActive ? ' !text-[#00d4c8] after:!w-full' : ''
                   }`}
                   onClick={(e) => handleNavClick(e, link.id)}
-                  aria-current={isActive ? "true" : undefined}
+                  aria-current={isActive ? 'true' : undefined}
                 >
                   {link.label}
                 </a>
               );
             })}
-          <div className="flex flex-row justify-center items-center px-6 py-3.5 gap-10 bg-gradient-card border-t border-[rgba(0,128,128,0.3)] rounded-[30px]">
-            {navLinks.map((link) => (
-              <a
-                key={link.id}
-                href={link.href}
-                className={`text-white no-underline text-base font-normal relative transition-colors duration-300 cursor-pointer hover:text-primary after:content-[''] after:absolute after:-bottom-1.5 after:left-0 after:w-0 after:h-0.5 after:bg-gradient-primary after:transition-all after:duration-300 hover:after:w-full ${
-                  activeSection === link.id ? 'text-primary after:!w-full' : ''
-                }`}
-                onClick={(e) => { e.preventDefault(); handleNavClick(link.id); }}
-                aria-current={activeSection === link.id ? 'true' : undefined}
-              >
-                {link.label}
-              </a>
-            ))}
           </div>
 
           {/* CTA Buttons */}
@@ -135,32 +103,21 @@ const Navbar: React.FC = () => {
               {navLinks.map((link) => {
                 const isActive = activeSectionId === link.id;
                 return (
-                  <a
-                    key={link.id}
+                  
+                   <a key={link.id}
                     href={link.href}
                     className={`no-underline text-base font-medium transition-colors duration-300 cursor-pointer ${
                       isActive
-                        ? "text-[#00d4c8]"
-                        : "text-[#E0E0E0] hover:text-[#00d4c8]"
+                        ? 'text-[#00d4c8]'
+                        : 'text-[#E0E0E0] hover:text-[#00d4c8]'
                     }`}
                     onClick={(e) => handleNavClick(e, link.id)}
-                    aria-current={isActive ? "true" : undefined}
+                    aria-current={isActive ? 'true' : undefined}
                   >
                     {link.label}
                   </a>
                 );
               })}
-              {navLinks.map((link) => (
-                <a
-                  key={link.id}
-                  href={link.href}
-                  className={`text-[#E0E0E0] no-underline text-base font-medium transition-colors duration-300 cursor-pointer hover:text-primary ${activeSection === link.id ? 'text-primary' : ''}`}
-                  onClick={(e) => { e.preventDefault(); handleNavClick(link.id); }}
-                  aria-current={activeSection === link.id ? 'true' : undefined}
-                >
-                  {link.label}
-                </a>
-              ))}
             </div>
             <div className="flex flex-col gap-3">
               <Link to="/login" className="w-full text-center px-5 py-2.5 rounded-full no-underline font-medium text-lg transition-all duration-300 text-white font-display bg-transparent hover:-translate-y-0.5">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,16 +135,24 @@ html {
 }
 
 @keyframes logo-scroll {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(-50%);
-  }
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+.logo-strip-wrapper {
+  overflow: hidden;
+  width: 100%;
 }
 
 .logo-strip-track {
+  display: flex;
+  width: max-content;
+  gap: 2.5rem;
   animation: logo-scroll 28s linear infinite;
+}
+
+.logo-strip-wrapper:hover .logo-strip-track {
+  animation-play-state: paused;
 }
 
 @media print {


### PR DESCRIPTION
## Summary
Closes #257

Adds a horizontally scrolling logo strip on the landing page showing the technology ecosystem and logistics partners Navin works with.

## Changes
- Created `frontend/src/LandingPage/sections/LogoStrip/LogoStrip.tsx` with Stellar, Soroban and 5 partner wordmarks (Shipbob, FedEx, DHL, Maersk, Flexport)
- Continuous horizontal marquee animation using CSS `@keyframes logo-scroll`
- Pause on hover implemented via pure CSS `animation-play-state: paused` on `.logo-strip-wrapper:hover`
- Updated `frontend/src/index.css` with wrapper hover rule
- Fixed pre-existing duplicate merge artifact in `Navbar.tsx`

## Acceptance Criteria
- [x] Logo strip renders between Hero and How It Works sections
- [x] Marquee scrolls continuously and pauses on hover
- [x] No layout shift on mobile