### PR TITLE
feat: add shared search/tag components and public tracking notes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import PaginationDemo from './pages/ComponentDemos/PaginationDemo/PaginationDemo
 import PageSkeleton from './components/ui/PageSkeleton';
 import { AuthProvider } from './context/AuthContext';
 import { realtimeService } from './services/realtime/realtimeService';
+import PublicTrackingPage from './pages/PublicTracking/PublicTrackingPage';
 import './App.css';
 
 // Eagerly loaded (critical path)
@@ -56,6 +57,7 @@ const router = createBrowserRouter([
   { path: '/register/verify-email', element: <EmailVerification /> },
   { path: '/accept-invitation', element: S(<AcceptInvitation />) },
   { path: '/pagination-demo', element: <PaginationDemo /> },
+  { path: '/track/:trackingNumber', element: <PublicTrackingPage /> },
   {
     element: <ProtectedRoute />,
     children: [

--- a/frontend/src/components/ui/SearchInput.test.tsx
+++ b/frontend/src/components/ui/SearchInput.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import SearchInput from './SearchInput';
+
+describe('SearchInput', () => {
+  it('debounces value changes until typing pauses', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = vi.fn();
+
+    render(<SearchInput value="" onChange={onChange} debounceMs={300} />);
+
+    const input = screen.getByPlaceholderText('Search...');
+    await user.type(input, 'abc');
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(onChange).toHaveBeenCalledWith('abc');
+  });
+
+  it('clears the value and refocuses the input when the clear button is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = vi.fn();
+
+    render(<SearchInput value="shipment" onChange={onChange} />);
+
+    const clearButton = screen.getByRole('button', { name: /clear search/i });
+    await user.click(clearButton);
+
+    const input = screen.getByPlaceholderText('Search...');
+
+    expect(input).toHaveValue('');
+    expect(onChange).toHaveBeenCalledWith('');
+    expect(input).toHaveFocus();
+  });
+});

--- a/frontend/src/components/ui/SearchInput.tsx
+++ b/frontend/src/components/ui/SearchInput.tsx
@@ -1,7 +1,7 @@
 import { Loader2, Search, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
-interface SearchInputProps {
+export interface SearchInputProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
@@ -23,13 +23,11 @@ const SearchInput: React.FC<SearchInputProps> = ({
 
   useEffect(() => {
     onChangeRef.current = onChange;
-  });
+  }, [onChange]);
 
   // Sync external value changes (e.g., programmatic clear from parent)
   useEffect(() => {
-    Promise.resolve().then(() => {
-      setInputValue(value);
-    });
+    setInputValue(value);
   }, [value]);
 
   // Debounce onChange — skip on initial mount to avoid double-firing on load
@@ -38,10 +36,12 @@ const SearchInput: React.FC<SearchInputProps> = ({
       hasMounted.current = true;
       return;
     }
-    const timer = setTimeout(() => {
+
+    const timer = window.setTimeout(() => {
       onChangeRef.current(inputValue);
     }, debounceMs);
-    return () => clearTimeout(timer);
+
+    return () => window.clearTimeout(timer);
   }, [inputValue, debounceMs]);
 
   const handleClear = () => {

--- a/frontend/src/components/ui/Tag.test.tsx
+++ b/frontend/src/components/ui/Tag.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Tag from './Tag';
+
+describe('Tag', () => {
+  it('renders the requested variant, size, icon and remove button', () => {
+    const onRemove = vi.fn();
+
+    render(
+      <Tag
+        label="Urgent"
+        variant="warning"
+        size="sm"
+        icon={<span data-testid="tag-icon">!</span>}
+        onRemove={onRemove}
+      />,
+    );
+
+    expect(screen.getByText('Urgent')).toBeInTheDocument();
+    expect(screen.getByTestId('tag-icon')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /remove urgent/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/Tag.tsx
+++ b/frontend/src/components/ui/Tag.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+export interface TagProps {
+  label: string;
+  variant?: 'default' | 'success' | 'warning' | 'danger' | 'info';
+  size?: 'sm' | 'md';
+  onRemove?: () => void;
+  icon?: React.ReactNode;
+}
+
+const variantClasses: Record<NonNullable<TagProps['variant']>, string> = {
+  default: 'border-slate-600/60 bg-slate-800/70 text-slate-100',
+  success: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+  warning: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  danger: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+  info: 'border-sky-500/40 bg-sky-500/10 text-sky-300',
+};
+
+const sizeClasses: Record<NonNullable<TagProps['size']>, string> = {
+  sm: 'px-2.5 py-1 text-xs',
+  md: 'px-3 py-1.5 text-sm',
+};
+
+const Tag: React.FC<TagProps> = ({ label, variant = 'default', size = 'md', onRemove, icon }) => {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border font-medium ${variantClasses[variant]} ${sizeClasses[size]}`}
+    >
+      {icon ? <span className="flex h-4 w-4 items-center justify-center">{icon}</span> : null}
+      <span>{label}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${label}`}
+          className="ml-0.5 flex h-4 w-4 items-center justify-center rounded-full text-current/80 transition hover:bg-black/10 hover:text-current"
+        >
+          <X size={12} />
+        </button>
+      ) : null}
+    </span>
+  );
+};
+
+export default Tag;

--- a/frontend/src/pages/PublicTracking/PublicTrackingPage.tsx
+++ b/frontend/src/pages/PublicTracking/PublicTrackingPage.tsx
@@ -1,0 +1,185 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import axios from 'axios';
+import { ArrowRightCircle, PackageCheck, Truck, AlertCircle } from 'lucide-react';
+import MilestoneTimeline from '../Shipment/sections/MilestoneTimeline/MilestoneTimeline';
+import type { Milestone } from '../Shipment/sections/MilestoneTimeline/types';
+
+interface PublicShipmentResponse {
+  data?: {
+    trackingNumber?: string;
+    status?: string;
+    origin?: string;
+    destination?: string;
+    expectedDeliveryDate?: string;
+    milestones?: Array<{
+      id?: string;
+      label?: string;
+      timestamp?: string;
+      location?: string;
+      status?: string;
+      isCompleted?: boolean;
+      isCurrent?: boolean;
+    }>;
+  };
+}
+
+const PublicTrackingPage: React.FC = () => {
+  const { trackingNumber } = useParams<{ trackingNumber: string }>();
+  const [shipment, setShipment] = useState<PublicShipmentResponse['data'] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchShipment = async () => {
+      if (!trackingNumber) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const response = await axios.get<PublicShipmentResponse>(`/api/public/shipments/${trackingNumber}`);
+        setShipment(response.data?.data ?? null);
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          setShipment(null);
+        } else {
+          setShipment(null);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchShipment();
+  }, [trackingNumber]);
+
+  const milestones = useMemo<Milestone[]>(() => {
+    if (!shipment?.milestones?.length) {
+      return [];
+    }
+
+    return shipment.milestones.map((milestone, index) => ({
+      id: milestone.id ?? `${milestone.label ?? 'milestone'}-${index}`,
+      status: (milestone.status as Milestone['status']) ?? 'Created',
+      label: milestone.label ?? 'Milestone',
+      timestamp: milestone.timestamp ?? 'Pending',
+      location: milestone.location,
+      isCompleted: milestone.isCompleted ?? index < shipment.milestones!.length - 1,
+      isCurrent: milestone.isCurrent ?? false,
+    }));
+  }, [shipment]);
+
+  const statusBadgeClass = useMemo(() => {
+    const normalized = (shipment?.status ?? '').toUpperCase();
+    if (normalized.includes('DELIVER')) return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
+    if (normalized.includes('TRANSIT') || normalized.includes('IN')) return 'bg-sky-500/15 text-sky-300 border-sky-500/30';
+    if (normalized.includes('CANCEL')) return 'bg-rose-500/15 text-rose-300 border-rose-500/30';
+    return 'bg-slate-500/15 text-slate-300 border-slate-500/30';
+  }, [shipment]);
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(ellipse_at_top,_#153344_0%,_#09131c_45%,_#04070b_100%)] text-slate-50">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-between px-6 py-10 lg:px-10">
+        <div>
+          <div className="mb-8 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-cyan-500/15 text-cyan-300">
+                <PackageCheck size={24} />
+              </div>
+              <div>
+                <p className="text-lg font-semibold tracking-[0.3em] text-white">NAVIN</p>
+                <p className="text-sm text-slate-400">Public shipment tracking</p>
+              </div>
+            </div>
+            <Link to="/signup" className="rounded-full border border-cyan-400/40 bg-cyan-400/10 px-4 py-2 text-sm font-medium text-cyan-300 transition hover:bg-cyan-400/20">
+              Create Account
+            </Link>
+          </div>
+
+          {isLoading ? (
+            <div className="rounded-3xl border border-slate-700/70 bg-slate-900/70 p-8 text-center text-slate-300">
+              Loading tracking information…
+            </div>
+          ) : !shipment ? (
+            <div className="rounded-3xl border border-rose-500/30 bg-slate-900/70 p-10 text-center shadow-2xl">
+              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-rose-500/10 text-rose-300">
+                <AlertCircle size={28} />
+              </div>
+              <h1 className="mb-3 text-3xl font-semibold text-white">Shipment not found</h1>
+              <p className="mx-auto max-w-xl text-slate-400">
+                We could not find a public shipment with this tracking number. Please check the link or contact the carrier.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-8">
+              <section className="rounded-3xl border border-slate-700/70 bg-slate-900/70 p-8 shadow-2xl backdrop-blur">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm uppercase tracking-[0.3em] text-slate-400">Tracking number</p>
+                    <h1 className="mt-2 text-3xl font-semibold text-white">{shipment.trackingNumber ?? trackingNumber}</h1>
+                  </div>
+                  <span className={`rounded-full border px-4 py-2 text-sm font-semibold ${statusBadgeClass}`}>
+                    {shipment.status ?? 'Unknown'}
+                  </span>
+                </div>
+
+                <div className="mt-8 grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+                  <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6">
+                    <div className="flex items-center gap-3 text-cyan-300">
+                      <Truck size={18} />
+                      <p className="text-sm font-semibold uppercase tracking-[0.25em]">Shipment overview</p>
+                    </div>
+                    <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Origin</p>
+                        <p className="mt-1 text-sm text-slate-200">{shipment.origin ?? 'Unavailable'}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Destination</p>
+                        <p className="mt-1 text-sm text-slate-200">{shipment.destination ?? 'Unavailable'}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Expected delivery</p>
+                        <p className="mt-1 text-sm text-slate-200">{shipment.expectedDeliveryDate ?? 'Pending'}</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-slate-800 bg-slate-950/70 p-6">
+                    <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Status banner</p>
+                    <div className="mt-4 rounded-2xl border border-cyan-500/20 bg-cyan-500/10 p-4 text-sm text-cyan-200">
+                      Your shipment is currently <span className="font-semibold">{shipment.status ?? 'in progress'}</span>.
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section className="rounded-3xl border border-slate-700/70 bg-slate-900/70 p-8 shadow-2xl backdrop-blur">
+                <div className="mb-4 flex items-center justify-between">
+                  <h2 className="text-2xl font-semibold text-white">Milestone timeline</h2>
+                  <span className="text-sm text-slate-400">Read-only view</span>
+                </div>
+                {milestones.length ? (
+                  <MilestoneTimeline milestones={milestones} />
+                ) : (
+                  <p className="rounded-2xl border border-dashed border-slate-700 bg-slate-950/40 p-6 text-sm text-slate-400">
+                    No milestone data is available for this shipment yet.
+                  </p>
+                )}
+              </section>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-10 rounded-3xl border border-slate-700/70 bg-slate-900/70 px-6 py-5 text-center text-sm text-slate-400">
+          <p className="mb-2">Need full shipment management and collaboration tools?</p>
+          <Link to="/signup" className="inline-flex items-center gap-2 font-semibold text-cyan-300 transition hover:text-cyan-200">
+            Create a Navin account <ArrowRightCircle size={16} />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PublicTrackingPage;

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,12 @@ import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
 import { afterEach, vi } from 'vitest'
 
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  value: true,
+  writable: true,
+  configurable: true,
+});
+
 // jsdom does not implement IntersectionObserver — provide a no-op stub.
 class IntersectionObserverMock {
   observe = vi.fn();


### PR DESCRIPTION
Closes #274 
Closes #273 
Closes #270 
Closes #268 


## Summary
- Added a reusable debounced search input with clear-button behavior
- Added a reusable tag/chip component with variants and removable support
- Added a public shipment tracking page at /track/:trackingNumber
- Added shipment notes thread UI with optimistic posting and visibility controls

## Verification
- pnpm exec vitest run src/components/ui/SearchInput.test.tsx src/components/ui/Tag.test.tsx src/pages/Shipment/sections/MilestoneTimeline/MilestoneTimeline.test.tsx
- pnpm build