### PR TITLE
feat: harden reusable CopyToClipboard button

### DIFF
--- a/frontend/src/components/ui/CopyToClipboard.tsx
+++ b/frontend/src/components/ui/CopyToClipboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { useToast } from '../../context/ToastContext';
 
@@ -6,26 +6,86 @@ interface CopyToClipboardProps {
   value: string;
   label?: string;
   size?: 'sm' | 'md';
+  /** How long, in ms, the "copied" checkmark stays visible. Defaults to 2000. */
+  successDuration?: number;
+  /** Extra classes appended to the button. */
+  className?: string;
 }
 
-const CopyToClipboard: React.FC<CopyToClipboardProps> = ({ value, label, size = 'md' }) => {
+/**
+ * Attempt to copy text without the async Clipboard API.
+ * Used as a fallback for insecure contexts / older browsers where
+ * `navigator.clipboard` is unavailable.
+ */
+function legacyCopy(value: string): boolean {
+  if (typeof document === 'undefined') return false;
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+  document.body.appendChild(textarea);
+  textarea.select();
+  let succeeded = false;
+  try {
+    succeeded = document.execCommand('copy');
+  } catch {
+    succeeded = false;
+  }
+  document.body.removeChild(textarea);
+  return succeeded;
+}
+
+const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
+  value,
+  label,
+  size = 'md',
+  successDuration = 2000,
+  className = '',
+}) => {
   const [copied, setCopied] = useState(false);
   const { addToast } = useToast();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending timer when the component unmounts.
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  const flagCopied = () => {
+    setCopied(true);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), successDuration);
+  };
 
   const handleCopy = async () => {
-    if (!navigator.clipboard) {
-      addToast('Clipboard API is not available in this browser', 'error');
-      return;
-    }
     try {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+        flagCopied();
+        return;
+      }
+      // Clipboard API unavailable — try the legacy path before giving up.
+      if (legacyCopy(value)) {
+        flagCopied();
+        return;
+      }
+      addToast('Clipboard is not available in this browser', 'error');
     } catch {
+      // writeText rejected (e.g. permissions) — attempt the fallback once more.
+      if (legacyCopy(value)) {
+        flagCopied();
+        return;
+      }
       addToast('Failed to copy to clipboard', 'error');
     }
   };
 
+  const isEmpty = value.length === 0;
   const iconSize = size === 'sm' ? 12 : 14;
   const btnClass =
     size === 'sm'
@@ -36,12 +96,14 @@ const CopyToClipboard: React.FC<CopyToClipboardProps> = ({ value, label, size = 
     <button
       type="button"
       onClick={handleCopy}
-      className={`${btnClass} border transition-colors ${
+      disabled={isEmpty}
+      className={`${btnClass} border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-40 disabled:cursor-not-allowed ${
         copied
           ? 'border-emerald-500/50 text-emerald-400 bg-emerald-500/10'
           : 'border-transparent text-text-secondary hover:text-primary hover:border-primary/30 hover:bg-primary/5'
-      }`}
-      aria-label={`Copy ${label ?? value}`}
+      } ${className}`}
+      aria-label={copied ? 'Copied to clipboard' : `Copy ${label ?? value}`}
+      aria-live="polite"
       title={value}
     >
       {copied ? <Check size={iconSize} /> : <Copy size={iconSize} />}


### PR DESCRIPTION
## Overview
The reusable `CopyToClipboard` component already exists at `frontend/src/components/ui/CopyToClipboard.tsx` and is integrated into the BlockchainLedger transaction-hash column. This PR hardens it for correctness, accessibility, and reliability while keeping the public API backward compatible.

## Changes
- **Fix a state-update-after-unmount bug**: the 2s reset timer is now tracked in a ref and cleared on unmount and before each new copy (previously it could fire after the component unmounted and overlap on rapid clicks).
- **Graceful clipboard fallback**: when `navigator.clipboard` is unavailable (insecure contexts / older browsers) or `writeText` rejects, fall back to a legacy `execCommand('copy')` path, only showing the error toast when both paths fail.
- **Accessibility**: disable the button for empty values, add `focus-visible` ring styling, and announce success via a dynamic `aria-label` + `aria-live`.
- **API**: add optional `successDuration` and `className` props (both backward compatible — existing usages are unaffected).

## Acceptance Criteria
- [x] Copies value to clipboard on click
- [x] Shows checkmark feedback for 2 seconds then reverts
- [x] Handles clipboard API unavailability gracefully with a toast (now with a fallback before the toast)
- [x] Integrated into BlockchainLedger transaction hash column

Closes #271