### PR TITLE
feat(dashboard): add revenue target and cost per route widgets

### DIFF
--- a/frontend/src/components/dashboard/CostPerRouteWidget/CostPerRouteWidget.test.tsx
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/CostPerRouteWidget.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CostPerRouteWidget from './CostPerRouteWidget';
+import { MOCK_ROUTE_COST_DATA } from './mockCostPerRouteData';
+
+describe('CostPerRouteWidget', () => {
+  it('renders chart view by default', () => {
+    render(<CostPerRouteWidget data={MOCK_ROUTE_COST_DATA} />);
+    expect(screen.getByText('Cost per Route')).toBeInTheDocument();
+    expect(screen.getByText('Base')).toBeInTheDocument();
+    expect(screen.getByText('Fuel')).toBeInTheDocument();
+  });
+
+  it('switches to table view and opens drill-down modal', () => {
+    render(<CostPerRouteWidget data={MOCK_ROUTE_COST_DATA} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Table/i }));
+    expect(screen.getByRole('columnheader', { name: 'Margin' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('New York, NY → Los Angeles, CA'));
+    expect(screen.getByText('Shipments on New York, NY → Los Angeles, CA')).toBeInTheDocument();
+    expect(screen.getByText('NV-001')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/CostPerRouteWidget/CostPerRouteWidget.tsx
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/CostPerRouteWidget.tsx
@@ -1,0 +1,224 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { BarChart3, Table2 } from 'lucide-react';
+import RouteShipmentsModal from './RouteShipmentsModal';
+import {
+  MOCK_ROUTE_COST_DATA,
+  type RouteCostData,
+} from './mockCostPerRouteData';
+import {
+  COST_SEGMENTS,
+  formatCurrency,
+  getMarginColorClass,
+  getRouteMarginPercent,
+  getRouteTotalCost,
+  toChartRow,
+} from './costPerRouteUtils';
+
+type ViewMode = 'chart' | 'table';
+
+interface CostPerRouteWidgetProps {
+  data?: RouteCostData[];
+}
+
+interface TooltipPayloadItem {
+  name?: string;
+  value?: number;
+  color?: string;
+  dataKey?: string;
+}
+
+interface RouteTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  label?: string;
+}
+
+function RouteTooltip({ active, payload, label }: RouteTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  const total = payload.reduce((sum, item) => sum + (item.value ?? 0), 0);
+
+  return (
+    <div className="rounded-lg border border-[#1e293b] bg-[#1a1f2e] px-3.5 py-2.5">
+      <div className="mb-2 text-[11px] font-semibold uppercase text-[#94a3b8]">{label}</div>
+      <div className="space-y-1 text-sm">
+        {payload.map((item) => (
+          <div key={item.dataKey} className="flex items-center justify-between gap-4">
+            <span className="text-[#cbd5e1]">{item.name}</span>
+            <span className="font-semibold text-white">{formatCurrency(item.value ?? 0)}</span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 border-t border-[#334155] pt-2 text-sm font-semibold text-white">
+        Total cost: {formatCurrency(total)}
+      </div>
+    </div>
+  );
+}
+
+const CostPerRouteWidget: React.FC<CostPerRouteWidgetProps> = ({
+  data = MOCK_ROUTE_COST_DATA,
+}) => {
+  const [viewMode, setViewMode] = useState<ViewMode>('chart');
+  const [selectedRoute, setSelectedRoute] = useState<RouteCostData | null>(null);
+
+  const sortedRoutes = useMemo(
+    () =>
+      [...data].sort((a, b) => getRouteTotalCost(b) - getRouteTotalCost(a)),
+    [data],
+  );
+
+  const topRoutes = useMemo(() => sortedRoutes.slice(0, 10), [sortedRoutes]);
+  const chartData = useMemo(() => topRoutes.map(toChartRow), [topRoutes]);
+
+  const openRoute = (routeName: string) => {
+    const route = data.find((entry) => entry.route === routeName) ?? null;
+    setSelectedRoute(route);
+  };
+
+  return (
+    <section className="rounded-2xl border border-[#1e293b] bg-[#14171e] p-6 shadow-sm h-full">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#64748b]">
+            Route Analytics
+          </p>
+          <h3 className="m-0 flex items-center gap-2 text-lg font-semibold text-white">
+            <BarChart3 size={18} className="text-[#60a5fa]" />
+            Cost per Route
+          </h3>
+        </div>
+
+        <div
+          className="flex rounded-full border border-[#1e293b] bg-[#0f172a] p-1"
+          role="group"
+          aria-label="Route analytics view mode"
+        >
+          <button
+            type="button"
+            aria-pressed={viewMode === 'chart'}
+            onClick={() => setViewMode('chart')}
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition ${
+              viewMode === 'chart' ? 'bg-[#2563eb] text-white' : 'text-[#94a3b8] hover:text-white'
+            }`}
+          >
+            <BarChart3 size={14} />
+            Chart
+          </button>
+          <button
+            type="button"
+            aria-pressed={viewMode === 'table'}
+            onClick={() => setViewMode('table')}
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition ${
+              viewMode === 'table' ? 'bg-[#2563eb] text-white' : 'text-[#94a3b8] hover:text-white'
+            }`}
+          >
+            <Table2 size={14} />
+            Table
+          </button>
+        </div>
+      </div>
+
+      {viewMode === 'chart' ? (
+        <>
+          <div className="mb-3 flex flex-wrap gap-3">
+            {COST_SEGMENTS.map((segment) => (
+              <div key={segment.key} className="flex items-center gap-2 text-xs text-[#94a3b8]">
+                <span
+                  className="h-2.5 w-2.5 rounded-sm"
+                  style={{ backgroundColor: segment.color }}
+                  aria-hidden="true"
+                />
+                {segment.label}
+              </div>
+            ))}
+          </div>
+
+          <div className="h-[360px] max-md:h-[300px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                layout="vertical"
+                margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
+              >
+                <CartesianGrid horizontal={false} stroke="#1e2433" strokeDasharray="3 3" />
+                <XAxis
+                  type="number"
+                  tick={{ fill: '#8a8f9d', fontSize: 11 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="route"
+                  width={150}
+                  tick={{ fill: '#8a8f9d', fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <Tooltip content={<RouteTooltip />} cursor={{ fill: 'rgba(59, 130, 246, 0.08)' }} />
+                {COST_SEGMENTS.map((segment) => (
+                  <Bar
+                    key={segment.key}
+                    dataKey={segment.key}
+                    name={segment.label}
+                    stackId="cost"
+                    fill={segment.color}
+                    radius={segment.key === 'insurance' ? [0, 4, 4, 0] : [0, 0, 0, 0]}
+                    onClick={(barData) => openRoute(String(barData.route))}
+                    className="cursor-pointer"
+                  />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-[#1e293b]">
+          <table className="min-w-full text-sm">
+            <thead className="bg-[#0f172a] text-left text-[#94a3b8]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Route</th>
+                <th className="px-4 py-3 font-medium">Cost</th>
+                <th className="px-4 py-3 font-medium">Revenue</th>
+                <th className="px-4 py-3 font-medium">Margin</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedRoutes.map((route) => {
+                const margin = getRouteMarginPercent(route);
+                return (
+                  <tr
+                    key={route.route}
+                    className="cursor-pointer border-t border-[#1e293b] text-[#cbd5e1] transition-colors hover:bg-[#0f172a]"
+                    onClick={() => setSelectedRoute(route)}
+                  >
+                    <td className="px-4 py-3">{route.route}</td>
+                    <td className="px-4 py-3">{formatCurrency(getRouteTotalCost(route))}</td>
+                    <td className="px-4 py-3">{formatCurrency(route.revenue)}</td>
+                    <td className={`px-4 py-3 font-semibold ${getMarginColorClass(margin)}`}>
+                      {margin.toFixed(1)}%
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <RouteShipmentsModal route={selectedRoute} onClose={() => setSelectedRoute(null)} />
+    </section>
+  );
+};
+
+export default CostPerRouteWidget;

--- a/frontend/src/components/dashboard/CostPerRouteWidget/RouteShipmentsModal.tsx
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/RouteShipmentsModal.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Modal from '../../common/Modal/Modal';
+import type { RouteCostData } from './mockCostPerRouteData';
+import { formatCurrency, getRouteMarginPercent, getRouteTotalCost, getMarginColorClass } from './costPerRouteUtils';
+
+interface RouteShipmentsModalProps {
+  route: RouteCostData | null;
+  onClose: () => void;
+}
+
+const RouteShipmentsModal: React.FC<RouteShipmentsModalProps> = ({ route, onClose }) => {
+  if (!route) return null;
+
+  const totalCost = getRouteTotalCost(route);
+  const margin = getRouteMarginPercent(route);
+
+  return (
+    <Modal
+      isOpen={!!route}
+      onClose={onClose}
+      title={`Shipments on ${route.route}`}
+      size="lg"
+    >
+      <div className="space-y-4">
+        <div className="grid gap-2 text-sm sm:grid-cols-3">
+          <div className="rounded-lg border border-[#1e293b] bg-[#0f172a] p-3">
+            <p className="m-0 text-xs text-[#94a3b8]">Total cost</p>
+            <p className="m-0 mt-1 font-semibold text-white">{formatCurrency(totalCost)}</p>
+          </div>
+          <div className="rounded-lg border border-[#1e293b] bg-[#0f172a] p-3">
+            <p className="m-0 text-xs text-[#94a3b8]">Revenue</p>
+            <p className="m-0 mt-1 font-semibold text-white">{formatCurrency(route.revenue)}</p>
+          </div>
+          <div className="rounded-lg border border-[#1e293b] bg-[#0f172a] p-3">
+            <p className="m-0 text-xs text-[#94a3b8]">Margin</p>
+            <p className={`m-0 mt-1 font-semibold ${getMarginColorClass(margin)}`}>
+              {margin.toFixed(1)}%
+            </p>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded-xl border border-[#1e293b]">
+          <table className="min-w-full text-sm">
+            <thead className="bg-[#0f172a] text-left text-[#94a3b8]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Tracking #</th>
+                <th className="px-4 py-3 font-medium">Shipment ID</th>
+                <th className="px-4 py-3 font-medium">Cost</th>
+                <th className="px-4 py-3 font-medium">Revenue</th>
+              </tr>
+            </thead>
+            <tbody>
+              {route.shipments.map((shipment) => (
+                <tr key={shipment.id} className="border-t border-[#1e293b] text-[#cbd5e1]">
+                  <td className="px-4 py-3">{shipment.trackingNumber}</td>
+                  <td className="px-4 py-3 font-mono text-xs">{shipment.id}</td>
+                  <td className="px-4 py-3">{formatCurrency(shipment.cost)}</td>
+                  <td className="px-4 py-3">{formatCurrency(shipment.revenue)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default RouteShipmentsModal;

--- a/frontend/src/components/dashboard/CostPerRouteWidget/costPerRouteUtils.test.ts
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/costPerRouteUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getMarginColorClass, getRouteMarginPercent, getRouteTotalCost } from './costPerRouteUtils';
+import { MOCK_ROUTE_COST_DATA } from './mockCostPerRouteData';
+
+describe('costPerRouteUtils', () => {
+  it('calculates total cost and margin', () => {
+    const route = MOCK_ROUTE_COST_DATA[0];
+    expect(getRouteTotalCost(route)).toBe(7070);
+    expect(getRouteMarginPercent(route)).toBeCloseTo(27.9, 1);
+  });
+
+  it('color-codes margin thresholds', () => {
+    expect(getMarginColorClass(25)).toBe('text-[#10b981]');
+    expect(getMarginColorClass(15)).toBe('text-[#f59e0b]');
+    expect(getMarginColorClass(5)).toBe('text-[#ef4444]');
+  });
+});

--- a/frontend/src/components/dashboard/CostPerRouteWidget/costPerRouteUtils.ts
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/costPerRouteUtils.ts
@@ -1,0 +1,43 @@
+import type { RouteCostData } from './mockCostPerRouteData';
+
+export const COST_SEGMENTS = [
+  { key: 'base', label: 'Base', color: '#3b82f6' },
+  { key: 'fuel', label: 'Fuel', color: '#f59e0b' },
+  { key: 'customs', label: 'Customs', color: '#8b5cf6' },
+  { key: 'insurance', label: 'Insurance', color: '#10b981' },
+] as const;
+
+export type CostSegmentKey = (typeof COST_SEGMENTS)[number]['key'];
+
+export function getRouteTotalCost(route: RouteCostData): number {
+  return route.base + route.fuel + route.customs + route.insurance;
+}
+
+export function getRouteMarginPercent(route: RouteCostData): number {
+  if (route.revenue <= 0) return 0;
+  return ((route.revenue - getRouteTotalCost(route)) / route.revenue) * 100;
+}
+
+export function getMarginColorClass(margin: number): string {
+  if (margin > 20) return 'text-[#10b981]';
+  if (margin >= 10) return 'text-[#f59e0b]';
+  return 'text-[#ef4444]';
+}
+
+export function formatCurrency(value: number): string {
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+export function toChartRow(route: RouteCostData) {
+  return {
+    route: route.route,
+    routeKey: route.route,
+    base: route.base,
+    fuel: route.fuel,
+    customs: route.customs,
+    insurance: route.insurance,
+    totalCost: getRouteTotalCost(route),
+    revenue: route.revenue,
+    margin: getRouteMarginPercent(route),
+  };
+}

--- a/frontend/src/components/dashboard/CostPerRouteWidget/index.ts
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from './CostPerRouteWidget';
+export { default as CostPerRouteWidget } from './CostPerRouteWidget';

--- a/frontend/src/components/dashboard/CostPerRouteWidget/mockCostPerRouteData.ts
+++ b/frontend/src/components/dashboard/CostPerRouteWidget/mockCostPerRouteData.ts
@@ -1,0 +1,166 @@
+export interface RouteShipment {
+  id: string;
+  trackingNumber: string;
+  cost: number;
+  revenue: number;
+}
+
+export interface RouteCostData {
+  route: string;
+  origin: string;
+  destination: string;
+  base: number;
+  fuel: number;
+  customs: number;
+  insurance: number;
+  revenue: number;
+  shipments: RouteShipment[];
+}
+
+export const MOCK_ROUTE_COST_DATA: RouteCostData[] = [
+  {
+    route: 'New York, NY → Los Angeles, CA',
+    origin: 'New York, NY',
+    destination: 'Los Angeles, CA',
+    base: 4200,
+    fuel: 1800,
+    customs: 650,
+    insurance: 420,
+    revenue: 9800,
+    shipments: [
+      { id: 'ship-001', trackingNumber: 'NV-001', cost: 7070, revenue: 9800 },
+      { id: 'ship-010', trackingNumber: 'NV-010', cost: 6200, revenue: 8900 },
+    ],
+  },
+  {
+    route: 'Chicago, IL → Houston, TX',
+    origin: 'Chicago, IL',
+    destination: 'Houston, TX',
+    base: 3100,
+    fuel: 1200,
+    customs: 280,
+    insurance: 310,
+    revenue: 6200,
+    shipments: [
+      { id: 'ship-002', trackingNumber: 'NV-002', cost: 4890, revenue: 6200 },
+    ],
+  },
+  {
+    route: 'Seattle, WA → Miami, FL',
+    origin: 'Seattle, WA',
+    destination: 'Miami, FL',
+    base: 5100,
+    fuel: 2400,
+    customs: 920,
+    insurance: 540,
+    revenue: 11200,
+    shipments: [
+      { id: 'ship-003', trackingNumber: 'NV-003', cost: 8960, revenue: 11200 },
+      { id: 'ship-011', trackingNumber: 'NV-011', cost: 8100, revenue: 10400 },
+    ],
+  },
+  {
+    route: 'Boston, MA → Denver, CO',
+    origin: 'Boston, MA',
+    destination: 'Denver, CO',
+    base: 2800,
+    fuel: 1100,
+    customs: 210,
+    insurance: 260,
+    revenue: 5400,
+    shipments: [
+      { id: 'ship-004', trackingNumber: 'NV-004', cost: 4370, revenue: 5400 },
+    ],
+  },
+  {
+    route: 'San Francisco, CA → Dallas, TX',
+    origin: 'San Francisco, CA',
+    destination: 'Dallas, TX',
+    base: 3600,
+    fuel: 1500,
+    customs: 430,
+    insurance: 350,
+    revenue: 7100,
+    shipments: [
+      { id: 'ship-005', trackingNumber: 'NV-005', cost: 5880, revenue: 7100 },
+    ],
+  },
+  {
+    route: 'Atlanta, GA → Phoenix, AZ',
+    origin: 'Atlanta, GA',
+    destination: 'Phoenix, AZ',
+    base: 2500,
+    fuel: 980,
+    customs: 180,
+    insurance: 220,
+    revenue: 4800,
+    shipments: [
+      { id: 'ship-006', trackingNumber: 'NV-006', cost: 3880, revenue: 4800 },
+    ],
+  },
+  {
+    route: 'Singapore → Los Angeles, CA',
+    origin: 'Singapore',
+    destination: 'Los Angeles, CA',
+    base: 6800,
+    fuel: 3200,
+    customs: 2100,
+    insurance: 780,
+    revenue: 15400,
+    shipments: [
+      { id: 'ship-007', trackingNumber: 'NV-007', cost: 12880, revenue: 15400 },
+    ],
+  },
+  {
+    route: 'Houston, TX → Seattle, WA',
+    origin: 'Houston, TX',
+    destination: 'Seattle, WA',
+    base: 3300,
+    fuel: 1400,
+    customs: 360,
+    insurance: 300,
+    revenue: 6900,
+    shipments: [
+      { id: 'ship-008', trackingNumber: 'NV-008', cost: 5360, revenue: 6900 },
+    ],
+  },
+  {
+    route: 'Miami, FL → Chicago, IL',
+    origin: 'Miami, FL',
+    destination: 'Chicago, IL',
+    base: 2900,
+    fuel: 1150,
+    customs: 250,
+    insurance: 240,
+    revenue: 5600,
+    shipments: [
+      { id: 'ship-009', trackingNumber: 'NV-009', cost: 4540, revenue: 5600 },
+    ],
+  },
+  {
+    route: 'Denver, CO → Boston, MA',
+    origin: 'Denver, CO',
+    destination: 'Boston, MA',
+    base: 2400,
+    fuel: 900,
+    customs: 160,
+    insurance: 190,
+    revenue: 4300,
+    shipments: [
+      { id: 'ship-012', trackingNumber: 'NV-012', cost: 3650, revenue: 4300 },
+    ],
+  },
+  {
+    route: 'Dallas, TX → San Francisco, CA',
+    origin: 'Dallas, TX',
+    destination: 'San Francisco, CA',
+    base: 2700,
+    fuel: 1050,
+    customs: 200,
+    insurance: 210,
+    revenue: 5000,
+    shipments: [
+      { id: 'ship-013', trackingNumber: 'NV-013', cost: 4160, revenue: 5000 },
+    ],
+  },
+];

--- a/frontend/src/components/dashboard/RevenueTargetWidget/RevenueTargetWidget.test.tsx
+++ b/frontend/src/components/dashboard/RevenueTargetWidget/RevenueTargetWidget.test.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import RevenueTargetWidget from './RevenueTargetWidget';
+import { MOCK_REVENUE_TARGET_DATA } from './mockRevenueTargetData';
+
+describe('RevenueTargetWidget', () => {
+  it('renders gauge center text, actual vs target, and projected EOM', () => {
+    render(<RevenueTargetWidget data={MOCK_REVENUE_TARGET_DATA} />);
+
+    expect(screen.getByText('Revenue vs Target')).toBeInTheDocument();
+    expect(screen.getByText('Actual')).toBeInTheDocument();
+    expect(screen.getByText('Target')).toBeInTheDocument();
+    expect(screen.getByText('Projected EOM')).toBeInTheDocument();
+    expect(screen.getByText(/of target/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Daily revenue sparkline')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/RevenueTargetWidget/RevenueTargetWidget.tsx
+++ b/frontend/src/components/dashboard/RevenueTargetWidget/RevenueTargetWidget.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from 'react';
+import { Target } from 'lucide-react';
+import { RadialBar, RadialBarChart, ResponsiveContainer } from 'recharts';
+import {
+  buildRevenueTargetData,
+  type RevenueTargetData,
+} from './mockRevenueTargetData';
+import {
+  buildSparklinePath,
+  formatCurrency,
+  getAchievementPercent,
+  getGaugeColor,
+  getProjectedEndOfMonthRevenue,
+} from './revenueTargetUtils';
+
+interface RevenueTargetWidgetProps {
+  data?: RevenueTargetData;
+}
+
+const RevenueTargetWidget: React.FC<RevenueTargetWidgetProps> = ({
+  data = buildRevenueTargetData(),
+}) => {
+  const achievementPercent = getAchievementPercent(data.actual, data.target);
+  const gaugeColor = getGaugeColor(achievementPercent);
+  const projectedRevenue = getProjectedEndOfMonthRevenue(data.actual);
+  const sparklinePath = useMemo(
+    () => buildSparklinePath(data.dailyRevenue.map((entry) => entry.amount)),
+    [data.dailyRevenue],
+  );
+
+  const gaugeData = [
+    {
+      name: 'Achievement',
+      value: Math.min(achievementPercent, 100),
+      fill: gaugeColor,
+    },
+  ];
+
+  return (
+    <section className="rounded-2xl border border-[#1e293b] bg-[#14171e] p-6 shadow-sm h-full">
+      <div className="mb-4">
+        <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#64748b]">
+          Monthly Target
+        </p>
+        <h3 className="flex items-center gap-2 text-lg font-semibold text-white m-0">
+          <Target size={18} className="text-[#60a5fa]" />
+          Revenue vs Target
+        </h3>
+      </div>
+
+      <div className="relative h-[220px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadialBarChart
+            cx="50%"
+            cy="50%"
+            innerRadius="68%"
+            outerRadius="100%"
+            barSize={18}
+            data={gaugeData}
+            startAngle={90}
+            endAngle={-270}
+          >
+            <RadialBar
+              dataKey="value"
+              cornerRadius={12}
+              background={{ fill: '#1e293b' }}
+            />
+          </RadialBarChart>
+        </ResponsiveContainer>
+
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+          <p className="m-0 text-2xl font-bold text-white">{formatCurrency(data.actual)}</p>
+          <p className="m-0 mt-1 text-sm font-semibold" style={{ color: gaugeColor }}>
+            {achievementPercent.toFixed(1)}% of target
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-2 grid gap-2 text-sm text-[#cbd5e1]">
+        <div className="flex items-center justify-between">
+          <span className="text-[#94a3b8]">Actual</span>
+          <span className="font-semibold text-white">{formatCurrency(data.actual)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-[#94a3b8]">Target</span>
+          <span className="font-semibold text-white">{formatCurrency(data.target)}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-[#94a3b8]">Projected EOM</span>
+          <span className="font-semibold text-[#60a5fa]">{formatCurrency(projectedRevenue)}</span>
+        </div>
+      </div>
+
+      <div className="mt-5 rounded-xl border border-[#1e293b] bg-[#0f172a] p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium text-[#cbd5e1]">Daily revenue</span>
+          <span className="text-xs uppercase tracking-[0.2em] text-[#64748b]">This month</span>
+        </div>
+        <svg viewBox="0 0 100 100" className="h-20 w-full" aria-label="Daily revenue sparkline">
+          <path
+            d={sparklinePath}
+            fill="none"
+            stroke={gaugeColor}
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    </section>
+  );
+};
+
+export default RevenueTargetWidget;

--- a/frontend/src/components/dashboard/RevenueTargetWidget/index.ts
+++ b/frontend/src/components/dashboard/RevenueTargetWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RevenueTargetWidget';
+export { default as RevenueTargetWidget } from './RevenueTargetWidget';

--- a/frontend/src/components/dashboard/RevenueTargetWidget/mockRevenueTargetData.ts
+++ b/frontend/src/components/dashboard/RevenueTargetWidget/mockRevenueTargetData.ts
@@ -1,0 +1,52 @@
+export interface DailyRevenue {
+  date: string;
+  amount: number;
+}
+
+export interface RevenueTargetData {
+  actual: number;
+  target: number;
+  dailyRevenue: DailyRevenue[];
+}
+
+function mulberry32(seed: number) {
+  return function random() {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function buildCurrentMonthDailyRevenue(now = new Date()): DailyRevenue[] {
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const dayOfMonth = now.getDate();
+  const random = mulberry32(year * 100 + month + 1);
+  const days: DailyRevenue[] = [];
+
+  for (let day = 1; day <= dayOfMonth; day += 1) {
+    const date = new Date(year, month, day);
+    const amount = Math.round((4200 + random() * 2800) * 100) / 100;
+    days.push({
+      date: date.toISOString().slice(0, 10),
+      amount,
+    });
+  }
+
+  return days;
+}
+
+export function buildRevenueTargetData(now = new Date()): RevenueTargetData {
+  const dailyRevenue = buildCurrentMonthDailyRevenue(now);
+  const actual = dailyRevenue.reduce((sum, entry) => sum + entry.amount, 0);
+  const target = 150000;
+
+  return {
+    actual,
+    target,
+    dailyRevenue,
+  };
+}
+
+export const MOCK_REVENUE_TARGET_DATA = buildRevenueTargetData();

--- a/frontend/src/components/dashboard/RevenueTargetWidget/revenueTargetUtils.test.ts
+++ b/frontend/src/components/dashboard/RevenueTargetWidget/revenueTargetUtils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getAchievementPercent,
+  getGaugeColor,
+  getProjectedEndOfMonthRevenue,
+} from './revenueTargetUtils';
+
+describe('revenueTargetUtils', () => {
+  it('calculates achievement percent', () => {
+    expect(getAchievementPercent(75000, 100000)).toBe(75);
+    expect(getAchievementPercent(120000, 100000)).toBe(120);
+  });
+
+  it('returns gauge colors by threshold', () => {
+    expect(getGaugeColor(120)).toBe('#10b981');
+    expect(getGaugeColor(85)).toBe('#3b82f6');
+    expect(getGaugeColor(60)).toBe('#f59e0b');
+    expect(getGaugeColor(30)).toBe('#ef4444');
+  });
+
+  it('projects end-of-month revenue from daily run rate', () => {
+    const projected = getProjectedEndOfMonthRevenue(50000, new Date(2026, 5, 15));
+    expect(projected).toBe(100000);
+  });
+});

--- a/frontend/src/components/dashboard/RevenueTargetWidget/revenueTargetUtils.ts
+++ b/frontend/src/components/dashboard/RevenueTargetWidget/revenueTargetUtils.ts
@@ -1,0 +1,42 @@
+export type GaugeColor = '#10b981' | '#3b82f6' | '#f59e0b' | '#ef4444';
+
+export function getAchievementPercent(actual: number, target: number): number {
+  if (target <= 0) return 0;
+  return (actual / target) * 100;
+}
+
+export function getGaugeColor(percent: number): GaugeColor {
+  if (percent >= 100) return '#10b981';
+  if (percent >= 75) return '#3b82f6';
+  if (percent >= 50) return '#f59e0b';
+  return '#ef4444';
+}
+
+export function getProjectedEndOfMonthRevenue(
+  actual: number,
+  now = new Date(),
+): number {
+  const dayOfMonth = now.getDate();
+  if (dayOfMonth <= 0) return actual;
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  return (actual / dayOfMonth) * daysInMonth;
+}
+
+export function formatCurrency(value: number): string {
+  return `$${value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+export function buildSparklinePath(values: number[]): string {
+  if (values.length === 0) return '';
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = max - min || 1;
+
+  return values
+    .map((value, index) => {
+      const x = (index / Math.max(values.length - 1, 1)) * 100;
+      const y = 100 - ((value - min) / range) * 100;
+      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(' ');
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -50,6 +50,8 @@ export { default as StatCard } from './dashboard/StatCard';
 export type { StatCardProps } from './dashboard/StatCard';
 export { default as DeliverySuccessChart } from './dashboard/Charts/DeliverySuccessChart';
 export { default as ShipmentVolumeChart } from './dashboard/Charts/ShipmentVolumeChart';
+export { default as RevenueTargetWidget } from './dashboard/RevenueTargetWidget';
+export { default as CostPerRouteWidget } from './dashboard/CostPerRouteWidget';
 
 // Shipment
 export { default as TrackingTimeline } from './shipment/TrackingTimeline';

--- a/frontend/src/pages/dashboard/Company/CompanyDashboard.tsx
+++ b/frontend/src/pages/dashboard/Company/CompanyDashboard.tsx
@@ -10,6 +10,7 @@ import RecentShipments from './RecentShipments/RecentShipments';
 import RecentActivityFeed from './RecentActivity/RecentActivityFeed';
 import ShipmentsMapWidget from './ShipmentsMap/ShipmentsMapWidget';
 import RevenueSummaryWidget from './RevenueSummary/RevenueSummaryWidget';
+import { CostPerRouteWidget, RevenueTargetWidget } from '@components';
 import OnboardingTour, { isTourComplete } from '@components/onboarding/OnboardingTour';
 import type { TourStep } from '@components/onboarding/OnboardingTour';
 
@@ -162,6 +163,11 @@ const CompanyDashboard: React.FC = () => {
         </div>
       </div>
       <RevenueSummaryWidget />
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <RevenueTargetWidget />
+        <CostPerRouteWidget />
+      </div>
 
       {/* Shipments */}
       <div className="flex flex-col">


### PR DESCRIPTION
## Summary
Resolves two open dashboard issues:

Closes #415
Closes #416

## Changes

### #415 — Cost per Route Analytics Widget
- Created `CostPerRouteWidget.tsx` with horizontal stacked bar chart for top 10 routes by cost
- Segmented bars by cost components: base, fuel, customs, insurance
- Added chart/table view toggle with margin color-coding (green > 20%, yellow 10–20%, red < 10%)
- Clicking a route opens a drill-down modal listing shipments on that route
- Tooltip shows per-segment cost breakdown

### #416 — Monthly Revenue vs Target Gauge Widget
- Created `RevenueTargetWidget.tsx` with Recharts RadialBarChart gauge
- Center text shows current revenue and % of target achieved
- Gauge fill color by threshold: green ≥ 100%, blue 75–99%, orange 50–74%, red < 50%
- Displays actual vs target values and projected end-of-month revenue from daily run rate
- Added daily revenue sparkline for the current month

### Integration
- Added both widgets to `CompanyDashboard.tsx` below `RevenueSummaryWidget`
- Exported widgets from `components/index.ts`

## Test plan
- [ ] Unit tests for gauge thresholds, margin calculations, widget rendering, table toggle, and route drill-down modal
- [ ] Open company dashboard and verify both widgets render side by side
- [ ] Confirm gauge color and center text update with achievement ratio
- [ ] Toggle Cost per Route chart/table views and open route modal from both views