### PR TITLE
feat: add public shipment tracking page with QR code

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,10 +18,12 @@
         "jose": "^6.2.3",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.575.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hot-toast": "^2.6.0",
         "react-leaflet": "^5.0.0",
+        "react-leaflet-cluster": "^4.1.3",
         "react-router-dom": "^7.0.0",
         "recharts": "^3.7.0",
         "workbox-window": "^7.4.1"
@@ -7577,6 +7579,15 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8617,6 +8628,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -8674,6 +8694,22 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-4.1.3.tgz",
+      "integrity": "sha512-b3ICS7r9Fs5hBWrFPMVnmkCuDewyG3m1GaGzamXY0eryyAXDfQ+ikSkiR/mVethueIIA5MSyLok2/KsZVotspQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "@react-leaflet/core": "^3.0.0",
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0"
       }
     },
     "node_modules/react-redux": {


### PR DESCRIPTION
## Description
Implements the public shipment tracking page and QR code generation for shareable tracking links.

## Changes Made
- Created `pages/PublicTracking/PublicTrackingPage.tsx` for the public tracking UI
- Added QR code modal in `pages/ShipmentDetail/ShareQRCodeModal/ShareQRCodeModal.tsx`
- Integrated share button in ShipmentDetailHeader
- Added route for `/track/:trackingNumber` in App.tsx
- Updated package-lock.json with required dependencies (qrcode.react)

## Issue Closes
Closes #410

## Testing
- [ ] Public page loads without authentication
- [ ] Shipment status, origin/destination, and estimated delivery display correctly
- [ ] Milestone timeline renders
- [ ] Share button copies link to clipboard
- [ ] QR code modal opens and is scannable
- [ ] Download PNG button works

## Screenshots
[Add screenshots here]