### PR TITLE
feat: implement notification preferences with phone verification

### DIFF
--- a/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.css
+++ b/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.css
@@ -1,3 +1,4 @@
+/* ====== Container ====== */
 .notif-pref-container {
   background-color: #14171E;
   border: 1px solid #1E293B;
@@ -6,6 +7,17 @@
   width: 100%;
 }
 
+.notif-pref-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 48px 24px;
+  color: #64748B;
+  font-size: 14px;
+}
+
+/* ====== Header ====== */
 .notif-pref-header {
   display: flex;
   align-items: center;
@@ -36,18 +48,164 @@
   margin: 0;
 }
 
+/* ====== Phone verification ====== */
+.notif-phone-section {
+  padding: 16px 24px;
+  border-bottom: 1px solid #1E293B;
+  background: rgba(30, 41, 59, 0.3);
+}
+
+.notif-phone-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.notif-phone-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #E2E8F0;
+}
+
+.notif-phone-verified {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #10B981;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.notif-phone-unverified {
+  font-size: 12px;
+  color: #F59E0B;
+}
+
+.notif-phone-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.notif-phone-row {
+  display: flex;
+  gap: 8px;
+}
+
+.notif-phone-input {
+  flex: 1;
+  background: #0F1117;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: #E2E8F0;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s;
+  min-width: 0;
+}
+
+.notif-phone-input:focus {
+  border-color: #3B82F6;
+}
+
+.notif-phone-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.notif-phone-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: #1E293B;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  color: #CBD5E1;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.notif-phone-btn:hover:not(:disabled) {
+  background: #293548;
+  border-color: #475569;
+}
+
+.notif-phone-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.notif-phone-btn--primary {
+  background: rgba(59, 130, 246, 0.15);
+  border-color: #3B82F6;
+  color: #60A5FA;
+}
+
+.notif-phone-btn--primary:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.notif-phone-error {
+  font-size: 12px;
+  color: #F87171;
+  margin: 2px 0 0;
+}
+
+/* ====== Channel column headers ====== */
+.notif-channel-header {
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+  padding: 8px 24px 0;
+}
+
+.notif-channel-label {
+  width: 44px;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: #64748B;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ====== Category groups ====== */
 .notif-pref-list {
-  padding: 8px 24px;
+  padding: 0 24px 8px;
   display: flex;
   flex-direction: column;
 }
 
+.notif-category {
+  padding: 16px 0 4px;
+}
+
+.notif-category + .notif-category {
+  border-top: 1px solid rgba(30, 41, 59, 0.6);
+}
+
+.notif-category-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 4px;
+}
+
+/* ====== Preference rows ====== */
 .notif-pref-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 0;
-  border-bottom: 1px solid rgba(30, 41, 59, 0.5);
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(30, 41, 59, 0.4);
   gap: 16px;
 }
 
@@ -55,23 +213,21 @@
   border-bottom: none;
 }
 
-.notif-pref-info {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
 .notif-pref-label {
-  font-size: 15px;
+  flex: 1;
+  font-size: 14px;
   font-weight: 500;
   color: #E2E8F0;
 }
 
-.notif-pref-desc {
-  font-size: 13px;
-  color: #64748B;
+.notif-pref-toggles {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-shrink: 0;
 }
 
+/* ====== Toggle switch ====== */
 .notif-switch {
   position: relative;
   display: inline-block;
@@ -116,6 +272,15 @@
   transform: translateX(20px);
 }
 
+.notif-switch--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.notif-switch--disabled .notif-slider {
+  cursor: not-allowed;
+}
+
 .notif-slider.round {
   border-radius: 24px;
 }
@@ -124,56 +289,22 @@
   border-radius: 50%;
 }
 
-.notif-pref-footer {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 16px;
-  padding: 20px 24px;
-  border-top: 1px solid #1E293B;
-}
-
-.notif-selection-count {
-  margin-right: auto;
-  font-size: 13px;
-  color: #94A3B8;
-}
-
-.notif-success-toast {
+/* ====== Inline saved indicator ====== */
+.notif-saved-indicator {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
+  font-size: 12px;
   color: #10B981;
-  background-color: rgba(16, 185, 129, 0.1);
-  padding: 8px 14px;
-  border-radius: 8px;
-  font-size: 13px;
   font-weight: 500;
-  animation: notifSlideIn 0.3s ease-out;
+  white-space: nowrap;
+  animation: notifFadeIn 0.25s ease-out;
 }
 
-.notif-save-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 20px;
-  background-color: #3B82F6;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.notif-save-btn:hover:not(:disabled) {
-  background-color: #2563EB;
-}
-
-.notif-save-btn:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
+/* ====== Animations ====== */
+@keyframes notifFadeIn {
+  from { opacity: 0; transform: translateY(3px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .notif-spinner {
@@ -181,43 +312,20 @@
 }
 
 @keyframes notifSpin {
-  100% {
-    transform: rotate(360deg);
-  }
+  100% { transform: rotate(360deg); }
 }
 
-@keyframes notifSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
+/* ====== Responsive ====== */
 @media (max-width: 640px) {
   .notif-pref-header,
   .notif-pref-list,
-  .notif-pref-footer {
+  .notif-phone-section,
+  .notif-channel-header {
     padding-left: 16px;
     padding-right: 16px;
   }
 
-  .notif-pref-footer {
-    flex-direction: column-reverse;
-    align-items: stretch;
-  }
-
-  .notif-selection-count {
-    margin: 0;
-    text-align: center;
-  }
-
-  .notif-save-btn {
-    justify-content: center;
-    width: 100%;
+  .notif-pref-label {
+    font-size: 13px;
   }
 }

--- a/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.test.tsx
+++ b/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.test.tsx
@@ -1,44 +1,245 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import NotificationPreferences from './NotificationPreferences';
+import * as notificationsEndpoint from '@services/api/endpoints/notifications';
 
-describe('NotificationPreferences', () => {
-  afterEach(() => {
-    vi.useRealTimers();
+// ---- Helpers ----
+
+const mockGetPreferences = vi.fn();
+const mockUpdatePreference = vi.fn();
+const mockSendOtp = vi.fn();
+const mockVerifyOtp = vi.fn();
+
+beforeEach(() => {
+  mockGetPreferences.mockClear();
+  mockUpdatePreference.mockClear();
+  mockSendOtp.mockClear();
+  mockVerifyOtp.mockClear();
+  vi.spyOn(notificationsEndpoint.notificationPreferencesApi, 'getPreferences').mockImplementation(mockGetPreferences);
+  vi.spyOn(notificationsEndpoint.notificationPreferencesApi, 'updatePreference').mockImplementation(mockUpdatePreference);
+  vi.spyOn(notificationsEndpoint.notificationPreferencesApi, 'sendOtp').mockImplementation(mockSendOtp);
+  vi.spyOn(notificationsEndpoint.notificationPreferencesApi, 'verifyOtp').mockImplementation(mockVerifyOtp);
+
+  // Default: resolve immediately with all-off preferences
+  mockGetPreferences.mockResolvedValue({
+    shipment_created: { email: false, sms: false },
+    status_changed: { email: false, sms: false },
+    delivery_confirmed: { email: false, sms: false },
+    payment_received: { email: false, sms: false },
+    dispute_opened: { email: false, sms: false },
+    dispute_resolved: { email: false, sms: false },
+  });
+  mockUpdatePreference.mockResolvedValue(undefined);
+  mockSendOtp.mockResolvedValue(undefined);
+  mockVerifyOtp.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---- Rendering ----
+
+describe('rendering', () => {
+  it('renders all 6 event types', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByLabelText('Shipment Created email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status Changed email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Delivery Confirmed email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Payment Received email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Dispute Opened email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Dispute Resolved email notifications')).toBeInTheDocument();
   });
 
-  it('renders all required notification categories', () => {
+  it('renders all 3 category headings', async () => {
     render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
 
-    expect(screen.getByLabelText('Shipment Updates in-app notifications')).toBeInTheDocument();
-    expect(screen.getByLabelText('Payment Alerts in-app notifications')).toBeInTheDocument();
-    expect(screen.getByLabelText('Delivery Confirmations in-app notifications')).toBeInTheDocument();
-    expect(screen.getByLabelText('System Announcements in-app notifications')).toBeInTheDocument();
+    expect(screen.getByText('Shipments')).toBeInTheDocument();
+    expect(screen.getByText('Payments')).toBeInTheDocument();
+    expect(screen.getByText('Disputes')).toBeInTheDocument();
   });
 
-  it('updates toggle states when a category is clicked', () => {
+  it('renders both Email and SMS toggles for each event', async () => {
     render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
 
-    const shipmentUpdates = screen.getByLabelText('Shipment Updates in-app notifications') as HTMLInputElement;
-    expect(shipmentUpdates.checked).toBe(true);
+    expect(screen.getByLabelText('Shipment Created email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Shipment Created SMS notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Payment Received email notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Payment Received SMS notifications')).toBeInTheDocument();
+  });
+});
 
-    fireEvent.click(shipmentUpdates);
-    expect(shipmentUpdates.checked).toBe(false);
+// ---- Toggle behaviour ----
+
+describe('toggle behaviour', () => {
+  it('calls updatePreference with correct args when email toggle is clicked', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByLabelText('Shipment Created email notifications'));
+
+    await waitFor(() =>
+      expect(mockUpdatePreference).toHaveBeenCalledWith('shipment_created', 'email', true),
+    );
   });
 
-  it('shows save loading state and success feedback', () => {
-    vi.useFakeTimers();
+  it('applies optimistic update immediately', async () => {
     render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
+    const toggle = screen.getByLabelText('Payment Received email notifications') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
 
-    expect(screen.getByRole('button', { name: /saving.../i })).toBeDisabled();
+    fireEvent.click(toggle);
+    expect(toggle.checked).toBe(true);
+  });
 
-    act(() => {
-      vi.advanceTimersByTime(1200);
+  it('rolls back on API error', async () => {
+    mockUpdatePreference.mockRejectedValueOnce(new Error('Network error'));
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    const toggle = screen.getByLabelText('Dispute Opened email notifications') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+
+    fireEvent.click(toggle);
+    // Optimistic: toggled on
+    expect(toggle.checked).toBe(true);
+
+    // After rejection: rolled back
+    await waitFor(() => expect(toggle.checked).toBe(false));
+  });
+
+  it('shows inline Saved indicator after successful update', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByLabelText('Status Changed email notifications'));
+
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument());
+  });
+});
+
+// ---- Phone verification ----
+
+describe('phone verification', () => {
+  it('SMS toggles are disabled before phone verification', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    const smsToggle = screen.getByLabelText('Shipment Created SMS notifications') as HTMLInputElement;
+    expect(smsToggle).toBeDisabled();
+  });
+
+  it('shows verification required message before verification', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByText('Phone verification required to enable SMS')).toBeInTheDocument();
+  });
+
+  it('sends OTP when Send OTP is clicked with a phone number', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Phone number'), { target: { value: '+15550001234' } });
+    fireEvent.click(screen.getByLabelText('Send OTP'));
+
+    await waitFor(() => expect(mockSendOtp).toHaveBeenCalledWith('+15550001234'));
+    expect(screen.getByLabelText('Verification code')).toBeInTheDocument();
+  });
+
+  it('shows error if Send OTP clicked without phone number', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByLabelText('Send OTP'));
+
+    expect(screen.getByText('Please enter a phone number.')).toBeInTheDocument();
+    expect(mockSendOtp).not.toHaveBeenCalled();
+  });
+
+  it('verifies OTP and enables SMS toggles', async () => {
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Phone number'), { target: { value: '+15550001234' } });
+    fireEvent.click(screen.getByLabelText('Send OTP'));
+    await waitFor(() => expect(mockSendOtp).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Verification code'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByLabelText('Verify OTP'));
+
+    await waitFor(() => expect(mockVerifyOtp).toHaveBeenCalledWith('+15550001234', '123456'));
+
+    // SMS toggles should now be enabled
+    const smsToggle = screen.getByLabelText('Shipment Created SMS notifications') as HTMLInputElement;
+    expect(smsToggle).not.toBeDisabled();
+
+    // Verified badge appears
+    expect(screen.getByLabelText('Phone verified')).toBeInTheDocument();
+  });
+
+  it('shows error when OTP verification fails', async () => {
+    mockVerifyOtp.mockRejectedValueOnce(new Error('Invalid OTP'));
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('Phone number'), { target: { value: '+15550001234' } });
+    fireEvent.click(screen.getByLabelText('Send OTP'));
+    await waitFor(() => expect(mockSendOtp).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Verification code'), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByLabelText('Verify OTP'));
+
+    await waitFor(() =>
+      expect(screen.getByText('Verification failed. Please check the code and try again.')).toBeInTheDocument(),
+    );
+
+    // SMS toggles remain disabled
+    expect(screen.getByLabelText('Shipment Created SMS notifications')).toBeDisabled();
+  });
+});
+
+// ---- Persistence ----
+
+describe('persistence', () => {
+  it('loads saved preferences from API on mount', async () => {
+    mockGetPreferences.mockResolvedValue({
+      shipment_created: { email: true, sms: false },
+      status_changed: { email: false, sms: false },
+      delivery_confirmed: { email: true, sms: false },
+      payment_received: { email: false, sms: false },
+      dispute_opened: { email: false, sms: false },
+      dispute_resolved: { email: true, sms: false },
     });
 
-    expect(screen.getByText('Preferences saved successfully!')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /save preferences/i })).toBeEnabled();
+    render(<NotificationPreferences />);
+    await waitFor(() => expect(mockGetPreferences).toHaveBeenCalledTimes(1));
+
+    const shipmentCreatedEmail = screen.getByLabelText('Shipment Created email notifications') as HTMLInputElement;
+    expect(shipmentCreatedEmail.checked).toBe(true);
+
+    const statusChangedEmail = screen.getByLabelText('Status Changed email notifications') as HTMLInputElement;
+    expect(statusChangedEmail.checked).toBe(false);
+
+    const disputeResolvedEmail = screen.getByLabelText('Dispute Resolved email notifications') as HTMLInputElement;
+    expect(disputeResolvedEmail.checked).toBe(true);
+  });
+
+  it('keeps defaults when API call fails on mount', async () => {
+    mockGetPreferences.mockRejectedValueOnce(new Error('Network error'));
+    render(<NotificationPreferences />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Shipment Created email notifications')).toBeInTheDocument(),
+    );
+
+    const toggle = screen.getByLabelText('Shipment Created email notifications') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
   });
 });

--- a/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.tsx
+++ b/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.tsx
@@ -1,128 +1,281 @@
-import React, { useMemo, useState } from 'react';
-import { Bell, Loader2, Save, CheckCircle2 } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Bell, CheckCircle2, Loader2 } from 'lucide-react';
+import {
+  type NotificationChannel,
+  type NotificationEventType,
+  type PreferencesMap,
+  notificationPreferencesApi,
+} from '@services/api/endpoints/notifications';
 import './NotificationPreferences.css';
 
-type NotificationPreferenceKey =
-  | 'shipmentUpdates'
-  | 'paymentAlerts'
-  | 'deliveryConfirmations'
-  | 'systemAnnouncements';
+// ---------- Data ----------
 
-interface NotificationCategory {
-  key: NotificationPreferenceKey;
+interface EventDef {
+  event: NotificationEventType;
   label: string;
-  description: string;
 }
 
-const CATEGORIES: NotificationCategory[] = [
+interface CategoryDef {
+  label: string;
+  events: EventDef[];
+}
+
+const CATEGORIES: CategoryDef[] = [
   {
-    key: 'shipmentUpdates',
-    label: 'Shipment Updates',
-    description: 'Get notified when shipment status changes or milestones are reached.',
+    label: 'Shipments',
+    events: [
+      { event: 'shipment_created', label: 'Shipment Created' },
+      { event: 'status_changed', label: 'Status Changed' },
+      { event: 'delivery_confirmed', label: 'Delivery Confirmed' },
+    ],
   },
   {
-    key: 'paymentAlerts',
-    label: 'Payment Alerts',
-    description: 'Receive alerts for payment settlements and transaction events.',
+    label: 'Payments',
+    events: [{ event: 'payment_received', label: 'Payment Received' }],
   },
   {
-    key: 'deliveryConfirmations',
-    label: 'Delivery Confirmations',
-    description: 'Be notified when deliveries are confirmed on-chain.',
-  },
-  {
-    key: 'systemAnnouncements',
-    label: 'System Announcements',
-    description: 'Platform updates, maintenance notices, and feature announcements.',
+    label: 'Disputes',
+    events: [
+      { event: 'dispute_opened', label: 'Dispute Opened' },
+      { event: 'dispute_resolved', label: 'Dispute Resolved' },
+    ],
   },
 ];
 
-type Preferences = Record<NotificationPreferenceKey, boolean>;
+const ALL_EVENTS = CATEGORIES.flatMap((c) => c.events.map((e) => e.event));
 
-const initialPreferences: Preferences = {
-  shipmentUpdates: true,
-  paymentAlerts: true,
-  deliveryConfirmations: true,
-  systemAnnouncements: false,
-};
+const defaultPreferences = (): PreferencesMap =>
+  Object.fromEntries(ALL_EVENTS.map((e) => [e, { email: false, sms: false }])) as PreferencesMap;
+
+// ---------- Component ----------
 
 const NotificationPreferences: React.FC = () => {
-  const [preferences, setPreferences] = useState<Preferences>(initialPreferences);
-  const [loading, setLoading] = useState(false);
-  const [successMsg, setSuccessMsg] = useState('');
+  const [prefs, setPrefs] = useState<PreferencesMap>(defaultPreferences);
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [savedEvent, setSavedEvent] = useState<NotificationEventType | null>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const enabledCount = useMemo(() => Object.values(preferences).filter(Boolean).length, [preferences]);
+  // Phone verification state
+  const [phone, setPhone] = useState('');
+  const [phoneVerified, setPhoneVerified] = useState(false);
+  const [otp, setOtp] = useState('');
+  const [otpSent, setOtpSent] = useState(false);
+  const [otpLoading, setOtpLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const [phoneError, setPhoneError] = useState('');
 
-  const toggle = (key: NotificationPreferenceKey) => {
-    setPreferences(prev => ({ ...prev, [key]: !prev[key] }));
-    setSuccessMsg('');
+  useEffect(() => {
+    notificationPreferencesApi
+      .getPreferences()
+      .then((data) => setPrefs(data))
+      .catch(() => {/* keep defaults on error */})
+      .finally(() => setLoadingInitial(false));
+  }, []);
+
+  const showSaved = useCallback((event: NotificationEventType) => {
+    setSavedEvent(event);
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    savedTimerRef.current = setTimeout(() => setSavedEvent(null), 2500);
+  }, []);
+
+  const handleToggle = async (event: NotificationEventType, channel: NotificationChannel) => {
+    const prev = prefs[event][channel];
+    const next = !prev;
+
+    // Optimistic update
+    setPrefs((p) => ({ ...p, [event]: { ...p[event], [channel]: next } }));
+
+    try {
+      await notificationPreferencesApi.updatePreference(event, channel, next);
+      showSaved(event);
+    } catch {
+      // Roll back
+      setPrefs((p) => ({ ...p, [event]: { ...p[event], [channel]: prev } }));
+    }
   };
 
-  const handleSave = () => {
-    setLoading(true);
-    setSuccessMsg('');
-
-    setTimeout(() => {
-      setLoading(false);
-      setSuccessMsg('Preferences saved successfully!');
-      setTimeout(() => setSuccessMsg(''), 3000);
-    }, 1200);
+  const handleSendOtp = async () => {
+    setPhoneError('');
+    if (!phone.trim()) {
+      setPhoneError('Please enter a phone number.');
+      return;
+    }
+    setOtpLoading(true);
+    try {
+      await notificationPreferencesApi.sendOtp(phone.trim());
+      setOtpSent(true);
+    } catch {
+      setPhoneError('Failed to send OTP. Please try again.');
+    } finally {
+      setOtpLoading(false);
+    }
   };
+
+  const handleVerifyOtp = async () => {
+    setPhoneError('');
+    if (!otp.trim()) {
+      setPhoneError('Please enter the verification code.');
+      return;
+    }
+    setVerifyLoading(true);
+    try {
+      await notificationPreferencesApi.verifyOtp(phone.trim(), otp.trim());
+      setPhoneVerified(true);
+      setOtpSent(false);
+      setOtp('');
+    } catch {
+      setPhoneError('Verification failed. Please check the code and try again.');
+    } finally {
+      setVerifyLoading(false);
+    }
+  };
+
+  if (loadingInitial) {
+    return (
+      <section className="notif-pref-container notif-pref-loading" aria-label="Loading notification preferences">
+        <Loader2 className="notif-spinner" size={24} />
+        <span>Loading preferences…</span>
+      </section>
+    );
+  }
 
   return (
     <section className="notif-pref-container" aria-labelledby="notification-preferences-title">
+      {/* Header */}
       <div className="notif-pref-header">
         <Bell className="notif-pref-icon" size={24} />
         <div>
           <h2 id="notification-preferences-title">Notification Preferences</h2>
-          <p>Choose which in-app notifications you want to receive.</p>
+          <p>Choose which events you want to be notified about, and through which channels.</p>
         </div>
       </div>
 
-      <div className="notif-pref-list">
-        {CATEGORIES.map(({ key, label, description }) => (
-          <div key={key} className="notif-pref-row">
-            <div className="notif-pref-info">
-              <span className="notif-pref-label">{label}</span>
-              <span className="notif-pref-desc">{description}</span>
-            </div>
-            <label className="notif-switch" htmlFor={key}>
-              <input
-                id={key}
-                type="checkbox"
-                checked={preferences[key]}
-                onChange={() => toggle(key)}
-                aria-label={`${label} in-app notifications`}
-              />
-              <span className="notif-slider round" />
-            </label>
-          </div>
-        ))}
-      </div>
+      {/* Phone verification */}
+      <div className="notif-phone-section">
+        <div className="notif-phone-header">
+          <span className="notif-phone-title">SMS Notifications</span>
+          {phoneVerified ? (
+            <span className="notif-phone-verified" aria-label="Phone verified">
+              <CheckCircle2 size={14} /> Verified
+            </span>
+          ) : (
+            <span className="notif-phone-unverified">Phone verification required to enable SMS</span>
+          )}
+        </div>
 
-      <div className="notif-pref-footer">
-        <span className="notif-selection-count" aria-live="polite">
-          {enabledCount} of {CATEGORIES.length} enabled
-        </span>
-        {successMsg && (
-          <div className="notif-success-toast" role="status">
-            <CheckCircle2 size={16} />
-            {successMsg}
+        {!phoneVerified && (
+          <div className="notif-phone-form">
+            <div className="notif-phone-row">
+              <input
+                type="tel"
+                className="notif-phone-input"
+                placeholder="+1 555 000 0000"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                aria-label="Phone number"
+                disabled={otpSent}
+              />
+              <button
+                className="notif-phone-btn"
+                onClick={handleSendOtp}
+                disabled={otpLoading || otpSent}
+                aria-label="Send OTP"
+              >
+                {otpLoading ? <Loader2 className="notif-spinner" size={14} /> : null}
+                {otpSent ? 'OTP Sent' : 'Send OTP'}
+              </button>
+            </div>
+
+            {otpSent && (
+              <div className="notif-phone-row">
+                <input
+                  type="text"
+                  className="notif-phone-input"
+                  placeholder="Enter verification code"
+                  value={otp}
+                  onChange={(e) => setOtp(e.target.value)}
+                  aria-label="Verification code"
+                  inputMode="numeric"
+                  maxLength={6}
+                />
+                <button
+                  className="notif-phone-btn notif-phone-btn--primary"
+                  onClick={handleVerifyOtp}
+                  disabled={verifyLoading}
+                  aria-label="Verify OTP"
+                >
+                  {verifyLoading ? <Loader2 className="notif-spinner" size={14} /> : null}
+                  Verify
+                </button>
+              </div>
+            )}
+
+            {phoneError && (
+              <p className="notif-phone-error" role="alert">
+                {phoneError}
+              </p>
+            )}
           </div>
         )}
-        <button className="notif-save-btn" onClick={handleSave} disabled={loading}>
-          {loading ? (
-            <>
-              <Loader2 className="notif-spinner" size={16} />
-              Saving...
-            </>
-          ) : (
-            <>
-              <Save size={16} />
-              Save Preferences
-            </>
-          )}
-        </button>
+      </div>
+
+      {/* Channel header */}
+      <div className="notif-channel-header" aria-hidden="true">
+        <span className="notif-channel-label">Email</span>
+        <span className="notif-channel-label">SMS</span>
+      </div>
+
+      {/* Categories */}
+      <div className="notif-pref-list">
+        {CATEGORIES.map((cat) => (
+          <div key={cat.label} className="notif-category">
+            <h3 className="notif-category-title">{cat.label}</h3>
+            {cat.events.map(({ event, label }) => (
+              <div key={event} className="notif-pref-row">
+                <span className="notif-pref-label">{label}</span>
+
+                <div className="notif-pref-toggles">
+                  {/* Email toggle */}
+                  <label className="notif-switch" htmlFor={`${event}-email`}>
+                    <input
+                      id={`${event}-email`}
+                      type="checkbox"
+                      checked={prefs[event]?.email ?? false}
+                      onChange={() => handleToggle(event, 'email')}
+                      aria-label={`${label} email notifications`}
+                    />
+                    <span className="notif-slider round" />
+                  </label>
+
+                  {/* SMS toggle */}
+                  <label
+                    className={`notif-switch ${!phoneVerified ? 'notif-switch--disabled' : ''}`}
+                    htmlFor={`${event}-sms`}
+                    title={!phoneVerified ? 'Verify your phone number to enable SMS' : undefined}
+                  >
+                    <input
+                      id={`${event}-sms`}
+                      type="checkbox"
+                      checked={prefs[event]?.sms ?? false}
+                      onChange={() => handleToggle(event, 'sms')}
+                      disabled={!phoneVerified}
+                      aria-label={`${label} SMS notifications`}
+                      aria-disabled={!phoneVerified}
+                    />
+                    <span className="notif-slider round" />
+                  </label>
+
+                  {/* Inline saved indicator */}
+                  {savedEvent === event && (
+                    <span className="notif-saved-indicator" role="status" aria-live="polite">
+                      <CheckCircle2 size={13} /> Saved
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/frontend/src/services/api/endpoints/notifications.ts
+++ b/frontend/src/services/api/endpoints/notifications.ts
@@ -1,5 +1,46 @@
 import { apiClient } from "../client";
 
+// ---------- Notification Preferences ----------
+
+export type NotificationChannel = "email" | "sms";
+
+export type NotificationEventType =
+  | "shipment_created"
+  | "status_changed"
+  | "delivery_confirmed"
+  | "payment_received"
+  | "dispute_opened"
+  | "dispute_resolved";
+
+export interface NotificationPreference {
+  event: NotificationEventType;
+  email: boolean;
+  sms: boolean;
+}
+
+export type PreferencesMap = Record<NotificationEventType, { email: boolean; sms: boolean }>;
+
+export const notificationPreferencesApi = {
+  getPreferences: async (): Promise<PreferencesMap> => {
+    const res = await apiClient.get<{ data: NotificationPreference[] }>("/notifications/preferences");
+    return Object.fromEntries(res.data.data.map((p) => [p.event, { email: p.email, sms: p.sms }])) as PreferencesMap;
+  },
+
+  updatePreference: async (event: NotificationEventType, channel: NotificationChannel, enabled: boolean): Promise<void> => {
+    await apiClient.patch("/notifications/preferences", { event, channel, enabled });
+  },
+
+  sendOtp: async (phone: string): Promise<void> => {
+    await apiClient.post("/notifications/phone/send-otp", { phone });
+  },
+
+  verifyOtp: async (phone: string, otp: string): Promise<void> => {
+    await apiClient.post("/notifications/phone/verify-otp", { phone, otp });
+  },
+};
+
+// ---------- Notifications ----------
+
 export type NotificationType = "all" | "shipments" | "settlements" | "system";
 export type NotificationIcon = "shipment" | "contract" | "alert" | "system" | "invoice" | "payment";
 


### PR DESCRIPTION
## Summary

Extends the notification preferences page to support Email and SMS channels for all required event types, with a phone verification gate before SMS can be enabled.

## Changes

### `src/services/api/endpoints/notifications.ts`
- Added `notificationPreferencesApi` with `getPreferences`, `updatePreference`, `sendOtp`, `verifyOtp`
- Added types: `NotificationEventType`, `NotificationChannel`, `PreferencesMap`

### `NotificationPreferences.tsx`
- 6 event types grouped into **Shipments**, **Payments**, **Disputes**
- Email and SMS toggle per event
- Optimistic updates with automatic rollback on API error
- Inline per-row **Saved** confirmation (no toast)
- Phone verification flow: enter number → Send OTP → enter code → Verify → SMS toggles unlock

### `NotificationPreferences.css`
- Channel header, category group styles, phone verification section, disabled toggle, saved indicator

### `NotificationPreferences.test.tsx`
- 15 tests: rendering, toggle behaviour, phone verification flow, persistence

## Test Results

```
✓ NotificationPreferences.test.tsx (15 tests) — all passing
```

No regressions introduced (pre-existing failures in BlockchainLedger and RevenueSummaryWidget are unrelated and present on `main` before these changes).

Closes #408