### PR TITLE
feat(ui): add MultiSelect component with tests

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -22,6 +22,8 @@ export { default as PriorityBadge } from './ui/PriorityBadge';
 export type { PriorityBadgeProps } from './ui/PriorityBadge';
 export { default as Tag } from './ui/Tag';
 export type { TagProps } from './ui/Tag';
+export { default as MultiSelect } from './ui/MultiSelect';
+export type { MultiSelectOption, MultiSelectProps } from './ui/MultiSelect';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
 
 export { default as Card, CardHeader, CardBody, CardFooter } from './Card';

--- a/frontend/src/components/ui/MultiSelect/MultiSelect.test.tsx
+++ b/frontend/src/components/ui/MultiSelect/MultiSelect.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import MultiSelect from './MultiSelect';
+
+describe('MultiSelect', () => {
+  const options = [
+    { label: 'Pending', value: 'pending' },
+    { label: 'In Transit', value: 'in-transit' },
+    { label: 'Delivered', value: 'delivered' },
+    { label: 'Customs', value: 'customs' },
+    { label: 'Shipped', value: 'shipped' },
+  ];
+
+  it('supports selecting, clearing, and searching options', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<MultiSelect options={options} value={[]} onChange={handleChange} placeholder="Select statuses" />);
+
+    await user.click(screen.getByRole('button', { name: /select statuses/i }));
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Pending'));
+    expect(handleChange).toHaveBeenCalledWith(['pending']);
+
+    await user.type(screen.getByPlaceholderText('Search options'), 'transit');
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+    expect(screen.getByText('In Transit')).toBeInTheDocument();
+  });
+
+  it('supports selecting all and showing overflow badges', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    const { rerender } = render(
+      <MultiSelect
+        options={options}
+        value={['pending', 'in-transit', 'delivered', 'customs', 'shipped']}
+        onChange={handleChange}
+        placeholder="Select statuses"
+      />,
+    );
+
+    expect(screen.getByText('+3 more')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /select statuses/i }));
+    await user.click(screen.getByLabelText('Select all'));
+    expect(handleChange).toHaveBeenCalledWith([]);
+
+    rerender(<MultiSelect options={options} value={[]} onChange={handleChange} placeholder="Select statuses" />);
+    expect(screen.getByText('Select statuses')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/MultiSelect/MultiSelect.tsx
+++ b/frontend/src/components/ui/MultiSelect/MultiSelect.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useId, useMemo, useState } from 'react';
+import { Check, ChevronDown, Search, X } from 'lucide-react';
+
+export interface MultiSelectOption {
+  label: string;
+  value: string;
+}
+
+export interface MultiSelectProps {
+  options: MultiSelectOption[];
+  value: string[];
+  onChange: (values: string[]) => void;
+  placeholder?: string;
+  searchable?: boolean;
+}
+
+const MultiSelect: React.FC<MultiSelectProps> = ({
+  options,
+  value,
+  onChange,
+  placeholder = 'Select options',
+  searchable = true,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const inputId = useId();
+
+  const filteredOptions = useMemo(() => {
+    if (!searchable || !searchTerm.trim()) {
+      return options;
+    }
+
+    const term = searchTerm.toLowerCase();
+    return options.filter((option) => option.label.toLowerCase().includes(term));
+  }, [options, searchable, searchTerm]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [searchTerm, isOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isOpen) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setHighlightedIndex((current) => (current + 1) % Math.max(filteredOptions.length, 1));
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setHighlightedIndex((current) => (current - 1 + Math.max(filteredOptions.length, 1)) % Math.max(filteredOptions.length, 1));
+      }
+
+      if (event.key === ' ' || event.key === 'Spacebar') {
+        event.preventDefault();
+        const option = filteredOptions[highlightedIndex];
+        if (option) {
+          const nextValues = value.includes(option.value)
+            ? value.filter((item) => item !== option.value)
+            : [...value, option.value];
+          onChange(nextValues);
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [filteredOptions, highlightedIndex, isOpen, onChange, value]);
+
+  const selectedOptions = options.filter((option) => value.includes(option.value));
+  const selectedCount = selectedOptions.length;
+
+  const toggleOption = (optionValue: string) => {
+    const nextValues = value.includes(optionValue)
+      ? value.filter((item) => item !== optionValue)
+      : [...value, optionValue];
+    onChange(nextValues);
+  };
+
+  const toggleAll = () => {
+    if (selectedCount === options.length) {
+      onChange([]);
+      return;
+    }
+
+    onChange(options.map((option) => option.value));
+  };
+
+  const handleTriggerKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      setIsOpen((current) => !current);
+    }
+  };
+
+  return (
+    <div className="relative w-full">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => setIsOpen((current) => !current)}
+        onKeyDown={handleTriggerKeyDown}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-label={placeholder}
+        className="flex min-h-11 w-full cursor-pointer items-center justify-between rounded-xl border border-slate-700 bg-slate-900/80 px-3 py-2.5 text-left text-sm text-slate-200 shadow-sm transition hover:border-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+      >
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          {selectedCount === 0 ? (
+            <span className="truncate text-slate-400">{placeholder}</span>
+          ) : (
+            <>
+              {selectedOptions.slice(0, 2).map((option) => (
+                <span key={option.value} className="inline-flex items-center gap-1 rounded-full border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs font-medium text-slate-100">
+                  {option.label}
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      toggleOption(option.value);
+                    }}
+                    aria-label={`Remove ${option.label}`}
+                    className="rounded-full p-0.5 text-slate-400 hover:bg-slate-700 hover:text-white"
+                  >
+                    <X size={12} />
+                  </button>
+                </span>
+              ))}
+              {selectedCount > 2 ? <span className="text-xs font-semibold text-sky-300">+{selectedCount - 2} more</span> : null}
+            </>
+          )}
+        </div>
+        <ChevronDown className={`ml-2 shrink-0 text-slate-400 transition ${isOpen ? 'rotate-180' : ''}`} size={18} />
+      </div>
+
+      {isOpen ? (
+        <div className="absolute z-20 mt-2 w-full rounded-xl border border-slate-700 bg-slate-950 p-2 shadow-2xl">
+          {searchable ? (
+            <div className="mb-2 flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-300">
+              <Search size={16} className="text-slate-400" />
+              <input
+                id={inputId}
+                type="text"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search options"
+                className="w-full border-none bg-transparent outline-none placeholder:text-slate-500"
+              />
+            </div>
+          ) : null}
+
+          <div className="mb-2 flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900/70 px-3 py-2">
+            <input
+              id="select-all"
+              type="checkbox"
+              checked={selectedCount === options.length && options.length > 0}
+              onChange={toggleAll}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-sky-500 focus:ring-sky-500"
+            />
+            <label htmlFor="select-all" className="cursor-pointer text-sm text-slate-200">
+              Select all
+            </label>
+          </div>
+
+          <div role="listbox" className="max-h-60 overflow-auto">
+            {filteredOptions.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-slate-400">No options found</div>
+            ) : (
+              filteredOptions.map((option, index) => {
+                const active = value.includes(option.value);
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-label={option.label}
+                    aria-selected={active}
+                    onClick={() => toggleOption(option.value)}
+                    className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm text-left transition ${
+                      highlightedIndex === index ? 'bg-slate-800 text-white' : 'text-slate-300 hover:bg-slate-800/70'
+                    }`}
+                  >
+                    <span>{option.label}</span>
+                    {active ? <Check size={16} className="text-sky-400" /> : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default MultiSelect;

--- a/frontend/src/components/ui/MultiSelect/index.ts
+++ b/frontend/src/components/ui/MultiSelect/index.ts
@@ -1,0 +1,2 @@
+export { default } from './MultiSelect';
+export type { MultiSelectOption, MultiSelectProps } from './MultiSelect';


### PR DESCRIPTION
Closes #394


# PR Title
Build reusable MultiSelect dropdown component

## Summary
Adds a reusable MultiSelect dropdown component for filter UIs across the app. It supports multi-selection, search, select-all, keyboard navigation, and overflow badges for large selections.

## What changed
- Added a new shared MultiSelect component at [frontend/src/components/ui/MultiSelect/MultiSelect.tsx](frontend/src/components/ui/MultiSelect/MultiSelect.tsx)
- Added component tests covering selection, search, select-all, and overflow badge behavior at [frontend/src/components/ui/MultiSelect/MultiSelect.test.tsx](frontend/src/components/ui/MultiSelect/MultiSelect.test.tsx)
- Exported the component from [frontend/src/components/index.ts](frontend/src/components/index.ts)

## Features
- Displays selected items as dismissible badges in the trigger
- Supports real-time filtering by search text
- Includes a select-all checkbox in the dropdown
- Supports keyboard navigation with arrow keys, Space, and Escape
- Shows a +N more badge when the selection exceeds the visible trigger area

## Testing
- Verified with:
  - pnpm vitest run src/components/ui/MultiSelect/MultiSelect.test.tsx
- Result: 2/2 tests passed

## Notes
- A broader TypeScript check still reports existing unrelated syntax issues in [frontend/src/pages/dashboard/Company/CompanyDashboard.tsx](frontend/src/pages/dashboard/Company/CompanyDashboard.tsx) and [frontend/src/pages/PublicTracking/PublicTrackingPage.tsx](frontend/src/pages/PublicTracking/PublicTrackingPage.tsx), but the new MultiSelect component files themselves are error-free.
