### PR TITLE
feat: add reusable ui/EmptyState component (#397)

### DIFF
--- a/frontend/src/components/ui/EmptyState/EmptyState.test.tsx
+++ b/frontend/src/components/ui/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import EmptyState from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders title', () => {
+    render(<EmptyState title="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(<EmptyState title="Title" description="Some description" />);
+    expect(screen.getByText('Some description')).toBeInTheDocument();
+  });
+
+  it('does not render description when omitted', () => {
+    render(<EmptyState title="Title" />);
+    expect(screen.queryByText('Some description')).not.toBeInTheDocument();
+  });
+
+  it('renders icon when provided', () => {
+    render(<EmptyState title="Title" icon={<span data-testid="icon" />} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('does not render CTA button when action is not provided', () => {
+    render(<EmptyState title="Title" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders CTA button when action is provided', async () => {
+    const onClick = vi.fn();
+    render(<EmptyState title="Title" action={{ label: 'Click me', onClick }} />);
+    const button = screen.getByRole('button', { name: 'Click me' });
+    expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  describe('NoShipments variant', () => {
+    it('renders with default content', () => {
+      render(<EmptyState.NoShipments />);
+      expect(screen.getByText('No shipments found')).toBeInTheDocument();
+    });
+
+    it('allows overriding props', () => {
+      render(<EmptyState.NoShipments title="Custom title" />);
+      expect(screen.getByText('Custom title')).toBeInTheDocument();
+    });
+  });
+
+  describe('NoResults variant', () => {
+    it('renders with default content', () => {
+      render(<EmptyState.NoResults />);
+      expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
+  });
+
+  describe('NoNotifications variant', () => {
+    it('renders with default content', () => {
+      render(<EmptyState.NoNotifications />);
+      expect(screen.getByText('No notifications')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/ui/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState/EmptyState.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import Button from '@components/Button';
+
+export interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: EmptyStateAction;
+  className?: string;
+}
+
+const EmptyState: React.FC<EmptyStateProps> & {
+  NoShipments: React.FC<Partial<EmptyStateProps>>;
+  NoResults: React.FC<Partial<EmptyStateProps>>;
+  NoNotifications: React.FC<Partial<EmptyStateProps>>;
+} = ({ icon, title, description, action, className = '' }) => {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-4 py-16 px-6 text-center ${className}`}
+    >
+      {icon && (
+        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-background-elevated border border-border text-text-secondary">
+          {icon}
+        </div>
+      )}
+      <div className="flex flex-col gap-2 max-w-sm">
+        <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+        {description && (
+          <p className="text-sm text-text-secondary">{description}</p>
+        )}
+      </div>
+      {action && (
+        <Button variant="primary" size="md" onClick={action.onClick}>
+          {action.label}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+const NoShipmentsIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M20 7H4a2 2 0 00-2 2v6a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M16 3H8l-2 4h12l-2-4z" />
+  </svg>
+);
+
+const NoResultsIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 115 11a6 6 0 0112 0z" />
+  </svg>
+);
+
+const NoNotificationsIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 00-9.33-4.999M9 17h6m-3 3a1 1 0 01-1-1h2a1 1 0 01-1 1z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18" />
+  </svg>
+);
+
+EmptyState.NoShipments = (props) => (
+  <EmptyState
+    icon={NoShipmentsIcon}
+    title="No shipments found"
+    description="You don't have any shipments yet. Create one to get started."
+    {...props}
+  />
+);
+EmptyState.NoShipments.displayName = 'EmptyState.NoShipments';
+
+EmptyState.NoResults = (props) => (
+  <EmptyState
+    icon={NoResultsIcon}
+    title="No results found"
+    description="Try adjusting your search or filter criteria."
+    {...props}
+  />
+);
+EmptyState.NoResults.displayName = 'EmptyState.NoResults';
+
+EmptyState.NoNotifications = (props) => (
+  <EmptyState
+    icon={NoNotificationsIcon}
+    title="No notifications"
+    description="You're all caught up! Check back later for updates."
+    {...props}
+  />
+);
+EmptyState.NoNotifications.displayName = 'EmptyState.NoNotifications';
+
+export default EmptyState;

--- a/frontend/src/components/ui/EmptyState/index.ts
+++ b/frontend/src/components/ui/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { default } from './EmptyState';
+export type { EmptyStateProps, EmptyStateAction } from './EmptyState';


### PR DESCRIPTION
## Summary

Resolves #397 — adds a flexible `EmptyState` component to `frontend/src/components/ui/EmptyState/`.

## Changes

- **`EmptyState.tsx`** — center-aligned layout component with:
  - `icon?`, `title`, `description?`, `action?` props
  - CTA button renders only when `action` prop is provided
  - Preset static variants: `EmptyState.NoShipments`, `EmptyState.NoResults`, `EmptyState.NoNotifications`
  - Responsive Tailwind-only styling (works on all screen widths)
- **`index.ts`** — barrel export
- **`EmptyState.test.tsx`** — 10 tests covering all acceptance criteria

## Acceptance Criteria

- [x] All props render correctly
- [x] CTA button only appears when `action` is provided
- [x] Preset variants render with correct default content
- [x] Component looks correct on mobile and desktop (Tailwind responsive utilities)

## Testing

All 10 EmptyState tests pass. The new files have zero lint errors/warnings.