### PR TITLE
feat(ui): add ProgressBar and CircularProgress components with tests (#297)

### DIFF
--- a/frontend/src/components/ui/CircularProgress/CircularProgress.test.tsx
+++ b/frontend/src/components/ui/CircularProgress/CircularProgress.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CircularProgress from './CircularProgress';
+
+describe('CircularProgress', () => {
+  it('renders with correct aria attributes', () => {
+    render(<CircularProgress value={65} />);
+    const el = screen.getByRole('progressbar');
+    expect(el).toHaveAttribute('aria-valuenow', '65');
+    expect(el).toHaveAttribute('aria-valuemin', '0');
+    expect(el).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('clamps value below 0 to 0', () => {
+    render(<CircularProgress value={-5} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('clamps value above 100 to 100', () => {
+    render(<CircularProgress value={120} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('shows percentage in SVG center text', () => {
+    render(<CircularProgress value={42} />);
+    expect(screen.getByText('42%')).toBeInTheDocument();
+  });
+
+  it('shows outer label when provided', () => {
+    render(<CircularProgress value={80} label="Escrow released" />);
+    expect(screen.getByText('Escrow released')).toBeInTheDocument();
+  });
+
+  it('renders SVG with two circles (track + arc)', () => {
+    const { container } = render(<CircularProgress value={50} />);
+    expect(container.querySelectorAll('circle')).toHaveLength(2);
+  });
+
+  it('applies stroke-dashoffset proportional to value', () => {
+    const size = 80;
+    const strokeWidth = 6;
+    const radius = (size - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const expectedOffset = circumference - (50 / 100) * circumference;
+
+    const { container } = render(<CircularProgress value={50} size={size} strokeWidth={strokeWidth} />);
+    const arc = container.querySelectorAll('circle')[1];
+    expect(Number(arc?.getAttribute('stroke-dashoffset'))).toBeCloseTo(expectedOffset, 1);
+  });
+});

--- a/frontend/src/components/ui/ProgressBar/ProgressBar.test.tsx
+++ b/frontend/src/components/ui/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ProgressBar from './ProgressBar';
+
+describe('ProgressBar', () => {
+  it('renders with correct aria attributes', () => {
+    render(<ProgressBar value={40} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '40');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('clamps value below 0 to 0', () => {
+    render(<ProgressBar value={-10} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('clamps value above 100 to 100', () => {
+    render(<ProgressBar value={150} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('shows label and percentage when label is provided', () => {
+    render(<ProgressBar value={75} label="Upload progress" />);
+    expect(screen.getByText('Upload progress')).toBeInTheDocument();
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('does not show percentage label when label is omitted', () => {
+    render(<ProgressBar value={50} />);
+    expect(screen.queryByText('50%')).not.toBeInTheDocument();
+  });
+
+  it('applies correct fill width via inline style', () => {
+    const { container } = render(<ProgressBar value={60} />);
+    const fill = container.querySelector('[style*="width: 60%"]');
+    expect(fill).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #297

Both components were already implemented in a prior commit. This PR adds the missing co-located tests and surfaces the work as a clean, reviewable branch.

## What's included

**`ProgressBar`** (`src/components/ui/ProgressBar/`)
- Props: `value`, `label?`, `color?` (blue/green/yellow/red), `size?` (sm/md/lg)
- Width animated with `transition-all duration-500`
- Optional percentage label to the right when `label` is provided
- `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
- Exported from `src/components/index.ts`

**`CircularProgress`** (`src/components/ui/CircularProgress/`)
- Props: `value`, `size?`, `strokeWidth?`, `label?`
- SVG arc with `stroke-dashoffset` animated via `transition-all duration-500`
- Center text shows percentage; optional outer label below
- `role="progressbar"` with full ARIA attributes
- Exported from `src/components/index.ts`

**Tests added** (13 passing)
- `ProgressBar.test.tsx`: aria attributes, value clamping (0/100), label display, fill width
- `CircularProgress.test.tsx`: aria attributes, value clamping, center %, outer label, SVG circle count, `stroke-dashoffset` math

## Acceptance Criteria

- [x] ProgressBar animates to the correct fill value
- [x] CircularProgress arc matches the value correctly  
- [x] Both have correct ARIA attributes
- [x] Both support all specified prop variations

## Screenshots

> ⚠️ _Please add a screenshot of both components rendered before merging (per CONTRIBUTING.md)._