### PR TITLE
feat: add two-factor auth backup codes, disable confirmation, and regenerate

### DIFF
--- a/frontend/src/pages/Settings/sections/SecuritySection/TwoFactorSetup.tsx
+++ b/frontend/src/pages/Settings/sections/SecuritySection/TwoFactorSetup.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Shield, ShieldCheck } from 'lucide-react';
+import { Shield, ShieldCheck, Copy, Download, RefreshCw } from 'lucide-react';
 import { apiClient } from '@services/api/client';
 
 const TwoFactorSetup: React.FC = () => {
@@ -9,6 +9,12 @@ const TwoFactorSetup: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [verified, setVerified] = useState(false);
+  const [backupCodes, setBackupCodes] = useState<string[]>([]);
+  const [showBackupCodes, setShowBackupCodes] = useState(false);
+  const [backupCodesAcknowledged, setBackupCodesAcknowledged] = useState(false);
+  const [disablePassword, setDisablePassword] = useState('');
+  const [showDisableModal, setShowDisableModal] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const handleEnable = async () => {
     setIsLoading(true);
@@ -29,8 +35,9 @@ const TwoFactorSetup: React.FC = () => {
     setIsLoading(true);
     setError(null);
     try {
-      await apiClient.post('/api/auth/2fa/verify', { code });
-      setVerified(true);
+      const res = await apiClient.post<{ data: { backupCodes: string[] } }>('/api/auth/2fa/verify', { code });
+      setBackupCodes(res.data.data.backupCodes);
+      setShowBackupCodes(true);
     } catch {
       setError('Invalid code. Please try again.');
     } finally {
@@ -38,15 +45,57 @@ const TwoFactorSetup: React.FC = () => {
     }
   };
 
+  const handleAcknowledgeBackupCodes = () => {
+    setBackupCodesAcknowledged(true);
+    setShowBackupCodes(false);
+    setVerified(true);
+  };
+
+  const handleCopyBackupCodes = () => {
+    navigator.clipboard.writeText(backupCodes.join('\n'));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownloadBackupCodes = () => {
+    const blob = new Blob([backupCodes.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'navin-2fa-backup-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const handleDisable = async () => {
+    if (!disablePassword) return;
     setIsLoading(true);
+    setError(null);
     try {
-      await apiClient.delete('/api/auth/2fa');
+      await apiClient.delete('/api/auth/2fa', { data: { password: disablePassword } });
       setEnabled(false);
       setQrUrl(null);
       setVerified(false);
+      setBackupCodes([]);
+      setBackupCodesAcknowledged(false);
+      setShowDisableModal(false);
+      setDisablePassword('');
     } catch {
-      setError('Could not disable 2FA.');
+      setError('Could not disable 2FA. Check your password.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRegenerateBackupCodes = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await apiClient.post<{ data: { backupCodes: string[] } }>('/api/auth/2fa/backup-codes/regenerate');
+      setBackupCodes(res.data.data.backupCodes);
+      setShowBackupCodes(true);
+    } catch {
+      setError('Could not regenerate backup codes.');
     } finally {
       setIsLoading(false);
     }
@@ -73,7 +122,7 @@ const TwoFactorSetup: React.FC = () => {
             {isLoading ? 'Setting up…' : 'Enable 2FA'}
           </button>
         </div>
-      ) : !verified ? (
+      ) : !verified && !showBackupCodes ? (
         <div className="space-y-4">
           {qrUrl && (
             <div className="bg-white p-3 inline-block rounded-lg">
@@ -99,19 +148,93 @@ const TwoFactorSetup: React.FC = () => {
             </button>
           </div>
         </div>
+      ) : showBackupCodes ? (
+        <div className="space-y-4">
+          <p className="text-sm text-yellow-400">Save these backup codes in a safe place. Each code can be used once.</p>
+          <div className="grid grid-cols-2 gap-2 bg-slate-800/50 p-4 rounded-lg">
+            {backupCodes.map((code, index) => (
+              <div key={index} className="text-sm font-mono text-white bg-slate-700/50 px-3 py-2 rounded text-center">
+                {code}
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={handleCopyBackupCodes}
+              className="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-800 flex items-center gap-2"
+            >
+              <Copy size={16} />
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+            <button
+              onClick={handleDownloadBackupCodes}
+              className="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-800 flex items-center gap-2"
+            >
+              <Download size={16} />
+              Download
+            </button>
+          </div>
+          <button
+            onClick={handleAcknowledgeBackupCodes}
+            className="px-4 py-2 bg-green-500 text-white text-sm font-semibold rounded-lg"
+          >
+            I've saved my backup codes
+          </button>
+        </div>
       ) : (
         <div className="space-y-3">
           <p className="text-sm text-green-400">2FA is active on your account.</p>
-          <button
-            onClick={handleDisable}
-            disabled={isLoading}
-            className="px-4 py-2 text-sm text-red-400 border border-red-400/30 rounded-lg hover:bg-red-400/10 disabled:opacity-50"
-          >
-            Disable 2FA
-          </button>
+          <div className="flex gap-3 flex-wrap">
+            <button
+              onClick={handleRegenerateBackupCodes}
+              disabled={isLoading}
+              className="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-800 flex items-center gap-2 disabled:opacity-50"
+            >
+              <RefreshCw size={16} />
+              Regenerate Backup Codes
+            </button>
+            <button
+              onClick={() => setShowDisableModal(true)}
+              disabled={isLoading}
+              className="px-4 py-2 text-sm text-red-400 border border-red-400/30 rounded-lg hover:bg-red-400/10 disabled:opacity-50"
+            >
+              Disable 2FA
+            </button>
+          </div>
         </div>
       )}
       {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {showDisableModal && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+          <div className="bg-[#0a1a1a] border border-[#62ffff]/30 rounded-2xl p-6 max-w-md w-full mx-4">
+            <h3 className="text-lg font-semibold text-white mb-4">Disable Two-Factor Authentication</h3>
+            <p className="text-sm text-slate-400 mb-4">Enter your current password to confirm you want to disable 2FA.</p>
+            <input
+              type="password"
+              value={disablePassword}
+              onChange={(e) => setDisablePassword(e.target.value)}
+              placeholder="Enter your password"
+              className="w-full bg-[rgba(19,186,186,0.05)] border border-[rgba(98,255,255,0.2)] rounded-lg px-3 py-2 text-sm text-white mb-4 focus:outline-none focus:border-[#62ffff]"
+            />
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setShowDisableModal(false)}
+                className="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDisable}
+                disabled={isLoading || !disablePassword}
+                className="px-4 py-2 bg-red-500 text-white text-sm font-semibold rounded-lg disabled:opacity-50"
+              >
+                {isLoading ? 'Disabling…' : 'Disable 2FA'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Closes #421

## Changes Made
- Added backup codes display after 2FA verification
- Added copy and download buttons for backup codes
- Added password confirmation modal when disabling 2FA
- Added regenerate backup codes button
- Updated verify API call to handle backup codes response
- Updated disable API call to send password

## Features
1. **Backup Codes**: After verifying 2FA, users are shown 8 one-time use backup codes
2. **Copy & Download**: Users can copy backup codes to clipboard or download them as a text file
3. **Password Confirmation**: Disabling 2FA requires entering the current password in a modal
4. **Regenerate Backup Codes**: After 2FA is enabled, users can regenerate backup codes

## Testing
- Tested enable 2FA flow
- Tested verify code and show backup codes
- Tested copy/download backup codes
- Tested disable 2FA with password confirmation
- Tested regenerate backup codes