### PR TITLE
Persist theme preference across sessions

### DIFF
--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, createElement, type ReactNode } from 'react';
 
 type Theme = 'dark' | 'light';
 
@@ -25,7 +25,14 @@ function applyTheme(theme: Theme) {
   }
 }
 
-export function useTheme() {
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   useEffect(() => {
@@ -34,22 +41,42 @@ export function useTheme() {
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = (e: MediaQueryListEvent) => {
+    const handleSystemChange = (e: MediaQueryListEvent) => {
       if (!localStorage.getItem(STORAGE_KEY)) {
         setTheme(e.matches ? 'dark' : 'light');
       }
     };
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
+    mq.addEventListener('change', handleSystemChange);
+
+    // Keep theme in sync across tabs/windows when the user changes it elsewhere.
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && (e.newValue === 'dark' || e.newValue === 'light')) {
+        setTheme(e.newValue);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      mq.removeEventListener('change', handleSystemChange);
+      window.removeEventListener('storage', handleStorage);
+    };
   }, []);
 
   const toggleTheme = useCallback(() => {
     setTheme((prev) => {
-      const next = prev === 'dark' ? 'light' : 'dark';
+      const next: Theme = prev === 'dark' ? 'light' : 'dark';
       localStorage.setItem(STORAGE_KEY, next);
       return next;
     });
   }, []);
 
-  return { theme, toggleTheme } as const;
+  return createElement(ThemeContext.Provider, { value: { theme, toggleTheme } }, children);
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import App from "./App.tsx";
 import { ToastProvider } from "./context/ToastContext.tsx";
 import { LiveRegionProvider } from "./context/LiveRegionContext.tsx";
 import { WalletProvider } from "./context/WalletContext.tsx";
+import { ThemeProvider } from "./hooks/useTheme.ts";
 
 if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
@@ -31,7 +32,9 @@ createRoot(document.getElementById("root")!).render(
     <LiveRegionProvider>
       <ToastProvider>
         <WalletProvider>
-          <App />
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
         </WalletProvider>
       </ToastProvider>
     </LiveRegionProvider>


### PR DESCRIPTION
## Summary
Theme persistence to localStorage already existed, but the theme value lived in a plain `useState` inside `useTheme`, so each component calling the hook (header `ThemeToggle`, Settings → Appearance) held its own independent copy. Toggling the theme in one place did not update the other, and opening a second tab could show a stale theme until reload.

This PR converts `useTheme` into a `ThemeProvider` context (mounted once in `main.tsx`, alongside the existing `ToastProvider`/`WalletProvider`) so there is a single source of truth. It also adds a `storage` event listener so a theme change made in one browser tab is reflected live in any other open tab of the app.

## Before / After
- Before: header toggle and Settings appearance toggle could disagree after a toggle in only one of them; persistence worked but only survived a full reload.
- After: both toggles always agree, theme choice persists across reloads/sessions (unchanged localStorage key `navin-theme`), and now also syncs live across open tabs.

## Testing
- Manual: toggled theme via header icon, confirmed Settings → Appearance reflects the new value without reload, and vice versa.
- Manual: reloaded the page and opened a second tab, confirmed the persisted/synced theme applied correctly and the existing pre-hydration script (`main.tsx`) still prevents a flash of the wrong theme.
- No new dependencies added; existing `prefers-color-scheme` fallback and manual override behavior preserved.

Closes #475