### PR TITLE
Improve form validation feedback for shipment creation and editing

### DIFF
--- a/frontend/src/pages/Settings/sections/MyTemplatesSection.tsx
+++ b/frontend/src/pages/Settings/sections/MyTemplatesSection.tsx
@@ -40,6 +40,7 @@ const MyTemplatesSection: React.FC = () => {
   const [editingTemplate, setEditingTemplate] = useState<ShipmentTemplate | null>(null);
   const [editName, setEditName] = useState('');
   const [editFields, setEditFields] = useState<ShipmentTemplateFields>(emptyFields);
+  const [editErrors, setEditErrors] = useState<Partial<Record<keyof ShipmentTemplateFields, string>>>({});
   const [deleteTarget, setDeleteTarget] = useState<ShipmentTemplate | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [order, setOrder] = useState<string[]>(loadStoredOrder);
@@ -95,10 +96,24 @@ const MyTemplatesSection: React.FC = () => {
     setEditingTemplate(template);
     setEditName(template.name);
     setEditFields({ ...template.fields });
+    setEditErrors({});
+  };
+
+  const validateEditFields = (): boolean => {
+    const newErrors: Partial<Record<keyof ShipmentTemplateFields, string>> = {};
+    if (!editFields.origin.trim()) newErrors.origin = 'Origin is required';
+    if (!editFields.destination.trim()) newErrors.destination = 'Destination is required';
+    if (!editFields.itemDescription.trim()) newErrors.itemDescription = 'Item description is required';
+    if (!editFields.weight || Number(editFields.weight) <= 0) newErrors.weight = 'Valid weight is required';
+    if (!editFields.recipientName.trim()) newErrors.recipientName = 'Recipient name is required';
+    if (!editFields.recipientContact.trim()) newErrors.recipientContact = 'Recipient contact is required';
+    setEditErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
   };
 
   const handleSaveEdit = async () => {
     if (!editingTemplate || !editName.trim()) return;
+    if (!validateEditFields()) return;
     setIsSaving(true);
     try {
       await updateTemplate(editingTemplate.id, {
@@ -280,21 +295,40 @@ const MyTemplatesSection: React.FC = () => {
             ] as const
           ).map(([key, label]) => (
             <div key={key} className={key === 'itemDescription' ? 'sm:col-span-2' : ''}>
-              <label className="mb-1 block text-sm font-medium text-white">{label}</label>
+              <label htmlFor={`edit-${key}`} className="mb-1 block text-sm font-medium text-white">
+                {label}
+              </label>
               {key === 'itemDescription' ? (
                 <textarea
+                  id={`edit-${key}`}
                   value={editFields[key]}
-                  onChange={(e) => setEditFields((prev) => ({ ...prev, [key]: e.target.value }))}
+                  onChange={(e) => {
+                    setEditFields((prev) => ({ ...prev, [key]: e.target.value }));
+                    setEditErrors((prev) => ({ ...prev, [key]: undefined }));
+                  }}
                   rows={3}
-                  className="w-full rounded-lg border border-[#1e293b] bg-[#0f172a] px-3 py-2 text-sm text-white"
+                  aria-invalid={!!editErrors[key]}
+                  aria-describedby={editErrors[key] ? `edit-${key}-error` : undefined}
+                  className={`w-full rounded-lg border bg-[#0f172a] px-3 py-2 text-sm text-white ${editErrors[key] ? 'border-[#ef4444]' : 'border-[#1e293b]'}`}
                 />
               ) : (
                 <input
+                  id={`edit-${key}`}
                   type="text"
                   value={editFields[key]}
-                  onChange={(e) => setEditFields((prev) => ({ ...prev, [key]: e.target.value }))}
-                  className="w-full rounded-lg border border-[#1e293b] bg-[#0f172a] px-3 py-2 text-sm text-white"
+                  onChange={(e) => {
+                    setEditFields((prev) => ({ ...prev, [key]: e.target.value }));
+                    setEditErrors((prev) => ({ ...prev, [key]: undefined }));
+                  }}
+                  aria-invalid={!!editErrors[key]}
+                  aria-describedby={editErrors[key] ? `edit-${key}-error` : undefined}
+                  className={`w-full rounded-lg border bg-[#0f172a] px-3 py-2 text-sm text-white ${editErrors[key] ? 'border-[#ef4444]' : 'border-[#1e293b]'}`}
                 />
+              )}
+              {editErrors[key] && (
+                <span id={`edit-${key}-error`} role="alert" className="mt-1 block text-xs text-[#fca5a5]">
+                  {editErrors[key]}
+                </span>
               )}
             </div>
           ))}

--- a/frontend/src/pages/dashboard/Company/CreateShipment/CreateShipment.tsx
+++ b/frontend/src/pages/dashboard/Company/CreateShipment/CreateShipment.tsx
@@ -154,17 +154,58 @@ useEffect(() => {
         }
     };
 
+    const FIELD_ORDER = [
+        'origin',
+        'destination',
+        'itemDescription',
+        'weight',
+        'expectedDeliveryDate',
+        'recipientName',
+        'recipientContact',
+    ] as const;
+
+    const validateField = (name: keyof FormData, data: FormData = formData): string => {
+        switch (name) {
+            case 'origin':
+                return data.origin.trim() ? '' : 'Origin address is required';
+            case 'destination':
+                return data.destination.trim() ? '' : 'Destination address is required';
+            case 'itemDescription':
+                return data.itemDescription.trim() ? '' : 'Item description is required';
+            case 'weight':
+                return data.weight && Number(data.weight) > 0 ? '' : 'Valid weight is required';
+            case 'recipientName':
+                return data.recipientName.trim() ? '' : 'Recipient name is required';
+            case 'recipientContact':
+                return data.recipientContact.trim() ? '' : 'Recipient contact is required';
+            case 'expectedDeliveryDate':
+                return data.expectedDeliveryDate ? '' : 'Expected delivery date is required';
+            default:
+                return '';
+        }
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name } = e.target;
+        const message = validateField(name as keyof FormData);
+        setErrors((prev: FormErrors) => ({ ...prev, [name]: message }));
+    };
+
     const validateForm = (): boolean => {
         const newErrors: FormErrors = {};
-        if (!formData.origin.trim()) newErrors.origin = 'Origin address is required';
-        if (!formData.destination.trim()) newErrors.destination = 'Destination address is required';
-        if (!formData.itemDescription.trim()) newErrors.itemDescription = 'Item description is required';
-        if (!formData.weight || Number(formData.weight) <= 0) newErrors.weight = 'Valid weight is required';
-        if (!formData.recipientName.trim()) newErrors.recipientName = 'Recipient name is required';
-        if (!formData.recipientContact.trim()) newErrors.recipientContact = 'Recipient contact is required';
-        if (!formData.expectedDeliveryDate) newErrors.expectedDeliveryDate = 'Expected delivery date is required';
+        FIELD_ORDER.forEach((field) => {
+            const message = validateField(field);
+            if (message) newErrors[field] = message;
+        });
 
         setErrors(newErrors);
+
+        const firstInvalidField = FIELD_ORDER.find((field) => newErrors[field]);
+        if (firstInvalidField) {
+            document.getElementById(firstInvalidField)?.focus();
+            addToast('Please fix the highlighted fields before submitting.', 'error');
+        }
+
         return Object.keys(newErrors).length === 0;
     };
 
@@ -335,6 +376,7 @@ useEffect(() => {
                           name="origin"
                           value={formData.origin}
                           onChange={handleInputChange}
+                          onBlur={handleBlur}
                           aria-invalid={!!errors.origin}
                           aria-describedby={errors.origin ? "origin-error" : undefined}
                           className={errors.origin ? 'input-error' : ''}
@@ -357,6 +399,7 @@ useEffect(() => {
                           name="destination"
                           value={formData.destination}
                           onChange={handleInputChange}
+                          onBlur={handleBlur}
                           aria-invalid={!!errors.destination}
                           aria-describedby={errors.destination ? "destination-error" : undefined}
                           className={errors.destination ? 'input-error' : ''}
@@ -372,6 +415,7 @@ useEffect(() => {
                           name="itemDescription"
                           value={formData.itemDescription}
                           onChange={handleInputChange}
+                          onBlur={handleBlur}
                           aria-invalid={!!errors.itemDescription}
                           aria-describedby={errors.itemDescription ? "itemDescription-error" : undefined}
                           className={errors.itemDescription ? 'input-error' : ''}
@@ -390,6 +434,7 @@ useEffect(() => {
                               name="weight"
                               value={formData.weight}
                               onChange={handleInputChange}
+                              onBlur={handleBlur}
                               aria-invalid={!!errors.weight}
                               aria-describedby={errors.weight ? "weight-error" : undefined}
                               className={errors.weight ? 'input-error' : ''}
@@ -408,6 +453,7 @@ useEffect(() => {
                               name="expectedDeliveryDate"
                               value={formData.expectedDeliveryDate}
                               onChange={handleInputChange}
+                              onBlur={handleBlur}
                               aria-invalid={!!errors.expectedDeliveryDate}
                               aria-describedby={errors.expectedDeliveryDate ? "expectedDeliveryDate-error" : undefined}
                               className={errors.expectedDeliveryDate ? 'input-error' : ''}
@@ -425,6 +471,7 @@ useEffect(() => {
                               name="recipientName"
                               value={formData.recipientName}
                               onChange={handleInputChange}
+                              onBlur={handleBlur}
                               aria-invalid={!!errors.recipientName}
                               aria-describedby={errors.recipientName ? "recipientName-error" : undefined}
                               className={errors.recipientName ? 'input-error' : ''}
@@ -441,6 +488,7 @@ useEffect(() => {
                               name="recipientContact"
                               value={formData.recipientContact}
                               onChange={handleInputChange}
+                              onBlur={handleBlur}
                               aria-invalid={!!errors.recipientContact}
                               aria-describedby={errors.recipientContact ? "recipientContact-error" : undefined}
                               className={errors.recipientContact ? 'input-error' : ''}


### PR DESCRIPTION
## Summary
Two gaps in shipment form validation feedback:

1. **Create Shipment** (`CreateShipment.tsx`): fields only validated on submit, so a user filling the form top-to-bottom got no feedback until the very end, and a failed submit didn't move focus or announce anything beyond inline red text — a problem for keyboard/screen-reader users.
2. **Edit Template modal** (`MyTemplatesSection.tsx`, used to edit reusable shipment field sets): had **no validation at all** — it silently saved blank or invalid fields (e.g. empty recipient name, zero/negative weight).

## Changes
- `CreateShipment.tsx`: added per-field `onBlur` validation so errors surface as soon as a field is left invalid, not just on submit. On a failed submit, focus now moves to the first invalid field and a toast summarizes that fields need attention.
- `MyTemplatesSection.tsx`: added the same required-field/valid-weight validation to the Edit Template modal, with per-field `aria-invalid`/`aria-describedby` and inline error text (`role="alert"`), clearing as each field is corrected. Save is blocked until the form is valid.

## Before / After
- Before: Create form only flagged problems after clicking submit; Edit Template modal accepted anything, including empty fields.
- After: both forms give immediate, accessible, per-field feedback, and invalid data can no longer be silently saved from either form.

## Testing
- Manual: tabbed through Create Shipment leaving fields blank, confirmed inline errors appear on blur and first invalid field receives focus on submit.
- Manual: opened Edit Template, cleared a required field, confirmed Save is blocked with an inline error, and confirmed a valid edit still saves correctly.
- No new dependencies; reused existing error text / `input-error` styling patterns already in the codebase.

Closes #474