### PR TITLE
Create loading skeletons for shipment detail and analytics views

### DIFF
--- a/frontend/src/pages/Analytics/Analytics.tsx
+++ b/frontend/src/pages/Analytics/Analytics.tsx
@@ -4,12 +4,13 @@ import {
   Clock,
   CheckCircle2,
   AlertTriangle,
-  Loader2,
   Calendar,
 } from "lucide-react";
 import StatCard, { type StatCardProps } from "../../components/dashboard/StatCard/StatCard";
 import ShipmentVolumeChart from "../../components/dashboard/Charts/ShipmentVolumeChart/ShipmentVolumeChart";
 import DeliverySuccessChart from "../../components/dashboard/Charts/DeliverySuccessChart/DeliverySuccessChart";
+import Skeleton from "../../components/ui/Skeleton/Skeleton";
+import DashboardWidgetSkeleton from "../../components/ui/Skeleton/DashboardWidgetSkeleton";
 import { analyticsApi } from "../../services/api/endpoints/analytics";
 import { shipmentApi } from "../../services/api/endpoints/shipments";
 import { anomalyApi } from "../../services/api/endpoints/anomalies";
@@ -170,9 +171,46 @@ const Analytics: React.FC = () => {
           </button>
         </div>
       ) : loading ? (
-        <div className="flex flex-col items-center justify-center p-24 gap-4">
-          <Loader2 className="animate-spin" size={32} />
-          <p className="text-[#94a3b8] text-sm">Loading analytics data...</p>
+        <div className="flex flex-col gap-6" aria-busy="true" aria-live="polite">
+          <span className="sr-only">Loading analytics data…</span>
+          <div className="grid grid-cols-4 gap-5 max-lg:grid-cols-2 max-sm:grid-cols-1">
+            {Array.from({ length: 4 }, (_, i) => (
+              <div key={i} className="bg-background-card border border-border rounded-2xl p-5">
+                <div className="flex justify-between items-start mb-5">
+                  <Skeleton width={40} height={40} rounded="lg" />
+                  <Skeleton width={48} height={14} />
+                </div>
+                <Skeleton width={90} height={12} className="mb-2" />
+                <Skeleton width={70} height={28} />
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-6 max-lg:grid-cols-1">
+            <DashboardWidgetSkeleton />
+            <DashboardWidgetSkeleton />
+          </div>
+
+          <div className="bg-[#14171e] border border-[#1e293b] rounded-2xl overflow-hidden">
+            <div className="px-6 py-5 border-b border-[#1e293b]">
+              <Skeleton width={160} height={18} />
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse">
+                <tbody>
+                  {Array.from({ length: 6 }, (_, i) => (
+                    <tr key={i}>
+                      {Array.from({ length: 5 }, (_, j) => (
+                        <td key={j} className="px-6 py-4 border-b border-[rgba(30,41,59,0.5)]">
+                          <Skeleton width={j === 3 ? 70 : 100} height={j === 3 ? 22 : 16} rounded={j === 3 ? 'full' : 'md'} />
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
       ) : (
         <div className="flex flex-col gap-6">

--- a/frontend/src/pages/ShipmentDetail/EscrowStatus/EscrowStatus.tsx
+++ b/frontend/src/pages/ShipmentDetail/EscrowStatus/EscrowStatus.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { ExternalLink, ShieldCheck, Loader2 } from "lucide-react";
+import { ExternalLink, ShieldCheck } from "lucide-react";
 import {
     settlementsApi,
     Settlement,
     SettlementStatus,
 } from "@services/api/endpoints/settlements";
+import Skeleton from "@components/ui/Skeleton/Skeleton";
 
 export interface EscrowStatusProps {
     shipmentId: string;
@@ -50,9 +51,20 @@ const EscrowStatus: React.FC<EscrowStatusProps> = ({ shipmentId }) => {
             </h2>
 
             {loading && (
-                <div className="flex items-center justify-center gap-3 py-10 text-[rgba(255,255,255,0.5)]">
-                    <Loader2 className="w-5 h-5 animate-spin" />
-                    <span>Loading escrow records…</span>
+                <div className="flex flex-col gap-4" aria-busy="true" aria-live="polite">
+                    <span className="sr-only">Loading escrow records…</span>
+                    {[0, 1].map((i) => (
+                        <div
+                            key={i}
+                            className="bg-[rgba(0,0,0,0.2)] rounded-2xl border border-[rgba(255,255,255,0.05)] px-6 py-5 flex flex-col gap-3"
+                        >
+                            <div className="flex items-center justify-between flex-wrap gap-3">
+                                <Skeleton width={120} height={22} />
+                                <Skeleton width={90} height={26} rounded="full" />
+                            </div>
+                            <Skeleton width={200} height={16} />
+                        </div>
+                    ))}
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
Both `Analytics.tsx` and the Escrow Status section of `ShipmentDetail.tsx` perform a real async fetch but rendered a generic centered spinner (`Loader2` + "Loading...") while waiting, instead of a layout-matching skeleton. That causes a visible layout jump the moment real content arrives, and gives the user no sense of the page's structure while it loads.

## Changes
- `Analytics.tsx`: loading state now renders skeleton stat cards (matching `StatCard`'s icon/trend/label/value layout), two chart-widget skeletons (reusing the existing `DashboardWidgetSkeleton`), and skeleton table rows matching the 5 real columns — instead of a bare spinner.
- `EscrowStatus.tsx` (Shipment Detail page): loading state now renders two settlement-card-shaped skeletons instead of a spinner.
- Both reuse the existing `Skeleton` / `DashboardWidgetSkeleton` primitives already in `components/ui/Skeleton`, no new dependency.
- Loading containers are marked `aria-busy="true" aria-live="polite"` with a visually-hidden status string, so assistive tech announces the loading state.

## Before / After
- Before: blank-ish center spinner, then a sudden pop-in of the full grid/table once data arrives.
- After: skeleton placeholders occupy the same grid/table shape immediately, so the transition to real content has no layout shift.

## Testing
- Manual: throttled network in devtools, confirmed both views show the shaped skeletons during the fetch and swap cleanly to real content/error/empty states.
- Confirmed responsive behavior at mobile/tablet/desktop breakpoints (skeleton grids use the same responsive classes as the real content).
- No new dependencies added.

Closes #473