### PR TITLE
Add responsive mobile navigation for dashboard and shipment pages

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, Outlet, useLocation } from 'react-router-dom';
 import {
   LayoutDashboard,
@@ -23,6 +23,9 @@ const DashboardLayout: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const sidebarRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const lastFocusedElement = useRef<HTMLElement | null>(null);
 
   const mainMenu = [
     { name: 'Dashboard', icon: <LayoutDashboard size={18} />, path: '/dashboard' },
@@ -41,8 +44,48 @@ const DashboardLayout: React.FC = () => {
     { name: 'Help Center', icon: <HelpCircle size={18} />, path: '/dashboard/help-center' },
   ];
 
-  const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
+  const toggleSidebar = () => {
+    if (!isSidebarOpen) {
+      lastFocusedElement.current = document.activeElement as HTMLElement;
+    }
+    setIsSidebarOpen((prev) => !prev);
+  };
   const closeSidebar = () => setIsSidebarOpen(false);
+
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+
+    document.body.style.overflow = 'hidden';
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeSidebar();
+        return;
+      }
+      if (e.key !== 'Tab' || !sidebarRef.current) return;
+      const focusable = sidebarRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+      lastFocusedElement.current?.focus();
+    };
+  }, [isSidebarOpen]);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-[#07090d] text-gray-900 dark:text-white font-sans flex">
@@ -62,6 +105,10 @@ const DashboardLayout: React.FC = () => {
 
       {/* Sidebar */}
       <aside
+        ref={sidebarRef}
+        role={isSidebarOpen ? 'dialog' : undefined}
+        aria-modal={isSidebarOpen || undefined}
+        aria-label="Main navigation"
         className={`
           w-65 bg-white dark:bg-[#0b0e14] border-r border-gray-200 dark:border-[#1e2433] flex flex-col shrink-0 p-6
           lg:relative lg:translate-x-0
@@ -73,6 +120,7 @@ const DashboardLayout: React.FC = () => {
           <img src="/images/logo.svg" alt="Navin Logo" className="w-8 h-8" />
           <span>NAVIN</span>
           <button
+            ref={closeButtonRef}
             className="ml-auto flex lg:hidden bg-transparent border-none text-slate-400 cursor-pointer"
             onClick={closeSidebar}
             aria-label="Close sidebar"


### PR DESCRIPTION
## Summary
The dashboard/shipment pages already had a responsive off-canvas mobile sidebar (hamburger toggle in `TopHeader`, slide-in `<aside>`, backdrop overlay), but it was missing the keyboard/focus behavior expected of that pattern:
- Escape did not close it
- Opening it did not move focus into the drawer, and closing it did not return focus to the hamburger button
- Tab could leave the drawer and reach the (invisible, overlaid) page content behind it
- The background page kept scrolling while the drawer was open on mobile

## Changes (`DashboardLayout.tsx`)
- Escape key now closes the mobile drawer.
- Opening the drawer moves focus to its close button; closing it (via Escape, backdrop click, X button, or navigating) restores focus to whatever element opened it.
- A focus trap keeps Tab/Shift+Tab cycling within the drawer while it's open.
- `document.body` scroll is locked while the drawer is open so the page behind the overlay doesn't scroll.
- The `<aside>` gets `role="dialog"` / `aria-modal="true"` only while the mobile drawer is actually open, so desktop (where the sidebar is always visible, non-modal) keeps normal landmark semantics.

## Before / After
- Before: visually correct mobile drawer, but keyboard/screen-reader users could tab out of it into hidden content, had no way to close it without a mouse, and the page behind it scrolled along with drawer content.
- After: the drawer behaves like a proper accessible dialog on mobile — trapped focus, Escape support, scroll lock, and focus restoration — with zero change to desktop behavior.

## Testing
- Manual: resized to a mobile viewport, opened the drawer via the hamburger icon, confirmed focus lands on the close button, Tab cycles within the drawer, Escape closes it and returns focus to the hamburger button, and the page behind stopped scrolling while open.
- Manual: confirmed desktop layout (sidebar always visible) is unchanged — no dialog role applied, no scroll lock.
- No new dependencies added.

Closes #472