### PR TITLE
Add analytics filters and slow-network/offline handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy, useEffect } from 'react';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import Home from './pages/Home/Home';
 import Signup from './pages/auth/Signup/Signup';
 import Login from './pages/auth/Login/Login';
@@ -14,6 +15,7 @@ import * as Sentry from '@sentry/react';
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 import ErrorFallback from './components/ErrorFallback/ErrorFallback';
 import OfflineBanner from './components/common/OfflineBanner/OfflineBanner';
+import SlowConnectionBanner from './components/common/SlowConnectionBanner/SlowConnectionBanner';
 import PWAInstallPrompt from './components/ui/PWAInstallPrompt';
 import PaginationDemo from './pages/ComponentDemos/PaginationDemo/PaginationDemo';
 import ConfirmDialogDemo from './pages/ComponentDemos/ConfirmDialogDemo/ConfirmDialogDemo';
@@ -125,7 +127,9 @@ function App() {
     <AuthProvider>
       <Sentry.ErrorBoundary fallback={(props) => <ErrorFallback {...props} />}>
         <ErrorBoundary>
+          <Toaster position="bottom-right" toastOptions={{ duration: 5000 }} />
           <OfflineBanner />
+          <SlowConnectionBanner />
           <RealtimeManager />
           <RouterProvider router={router} />
           <PWAInstallPrompt />

--- a/frontend/src/components/common/OfflineBanner/OfflineBanner.tsx
+++ b/frontend/src/components/common/OfflineBanner/OfflineBanner.tsx
@@ -1,12 +1,27 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { toast } from 'react-hot-toast';
 
 const OfflineBanner: React.FC = () => {
   const [isOnline, setIsOnline] = useState(() => navigator.onLine);
   const [dismissed, setDismissed] = useState(false);
+  // Only announce "back online" once we've actually observed an offline
+  // stretch in this session, so the toast doesn't fire on initial mount.
+  const wasOffline = useRef(false);
 
   useEffect(() => {
-    const handleOnline = () => { setIsOnline(true); setDismissed(false); };
-    const handleOffline = () => { setIsOnline(false); setDismissed(false); };
+    const handleOnline = () => {
+      setIsOnline(true);
+      setDismissed(false);
+      if (wasOffline.current) {
+        toast.success("You're back online.", { id: 'connection-restored' });
+        wasOffline.current = false;
+      }
+    };
+    const handleOffline = () => {
+      setIsOnline(false);
+      setDismissed(false);
+      wasOffline.current = true;
+    };
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
     return () => {

--- a/frontend/src/components/common/SlowConnectionBanner/SlowConnectionBanner.tsx
+++ b/frontend/src/components/common/SlowConnectionBanner/SlowConnectionBanner.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useCallback } from 'react';
+import { useSlowConnection } from '../../../hooks/useSlowConnection';
+import { useOnlineStatus } from '../../../hooks/useOnlineStatus';
+
+const SlowConnectionBanner: React.FC = () => {
+  const isOnline = useOnlineStatus();
+  const [dismissed, setDismissed] = useState(false);
+  // Re-arm the banner for a fresh slow spell whenever the browser reports
+  // a change, so a stale dismissal doesn't hide a brand-new slowdown.
+  const handleChange = useCallback((slow: boolean) => {
+    if (slow) setDismissed(false);
+  }, []);
+  const isSlow = useSlowConnection(handleChange);
+
+  // Mutually exclusive with OfflineBanner: only warn about a slow
+  // connection while actually online, so the two banners never stack.
+  if (!isOnline || !isSlow || dismissed) return null;
+
+  return (
+    <div
+      className="bg-slate-700 text-white px-4 py-3 text-center flex items-center justify-center gap-4 fixed top-0 left-0 right-0 z-[9999]"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="text-sm font-medium">
+        Your connection appears slow — some actions may take longer than usual.
+      </span>
+      <button
+        onClick={() => setDismissed(true)}
+        className="bg-white text-slate-700 px-3 py-1 rounded text-sm font-medium hover:bg-slate-100 transition-colors"
+        aria-label="Dismiss slow connection banner"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+};
+
+export default SlowConnectionBanner;

--- a/frontend/src/components/common/SlowConnectionBanner/index.ts
+++ b/frontend/src/components/common/SlowConnectionBanner/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SlowConnectionBanner';
+export { default as SlowConnectionBanner } from './SlowConnectionBanner';

--- a/frontend/src/hooks/useSlowConnection.ts
+++ b/frontend/src/hooks/useSlowConnection.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+
+// The Network Information API isn't in TS's default DOM lib and isn't
+// supported in every browser (notably Safari/Firefox) — this stays a
+// best-effort signal and degrades to `false` where it's unavailable.
+interface NetworkInformation extends EventTarget {
+  effectiveType?: 'slow-2g' | '2g' | '3g' | '4g';
+  saveData?: boolean;
+}
+
+const SLOW_EFFECTIVE_TYPES = new Set(['slow-2g', '2g']);
+
+function getConnection(): NetworkInformation | undefined {
+  return (navigator as Navigator & { connection?: NetworkInformation }).connection;
+}
+
+function computeIsSlow(): boolean {
+  const connection = getConnection();
+  if (!connection?.effectiveType) return false;
+  return SLOW_EFFECTIVE_TYPES.has(connection.effectiveType);
+}
+
+/**
+ * Best-effort "is the user on a slow connection" signal, via the Network
+ * Information API. `onChange` fires with the freshly-computed value whenever
+ * the browser reports a change, so callers can react (e.g. re-arm a
+ * dismissed banner) from a real event callback rather than deriving it in
+ * render.
+ */
+export function useSlowConnection(onChange?: (isSlow: boolean) => void): boolean {
+  const [isSlow, setIsSlow] = useState(computeIsSlow);
+
+  useEffect(() => {
+    const connection = getConnection();
+    if (!connection) return;
+
+    const update = () => {
+      const next = computeIsSlow();
+      setIsSlow(next);
+      onChange?.(next);
+    };
+    connection.addEventListener('change', update);
+    return () => connection.removeEventListener('change', update);
+  }, [onChange]);
+
+  return isSlow;
+}

--- a/frontend/src/pages/Analytics/Analytics.tsx
+++ b/frontend/src/pages/Analytics/Analytics.tsx
@@ -1,41 +1,43 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Package,
   Clock,
   CheckCircle2,
   AlertTriangle,
-  Calendar,
 } from "lucide-react";
 import StatCard, { type StatCardProps } from "../../components/dashboard/StatCard/StatCard";
 import ShipmentVolumeChart from "../../components/dashboard/Charts/ShipmentVolumeChart/ShipmentVolumeChart";
 import DeliverySuccessChart from "../../components/dashboard/Charts/DeliverySuccessChart/DeliverySuccessChart";
 import Skeleton from "../../components/ui/Skeleton/Skeleton";
 import DashboardWidgetSkeleton from "../../components/ui/Skeleton/DashboardWidgetSkeleton";
+import AnalyticsFilters, { type AnalyticsFiltersValues } from "./AnalyticsFilters";
 import { analyticsApi } from "../../services/api/endpoints/analytics";
 import { shipmentApi } from "../../services/api/endpoints/shipments";
 import { anomalyApi } from "../../services/api/endpoints/anomalies";
 import type { Shipment } from "../../services/api/endpoints/shipments";
+import { useLiveRegion } from "../../context/LiveRegionContext";
 
 interface AnalyticsMetrics {
-  totalShipments: number;
   onTimeRate: number;
   avgTransitDays: number;
   activeAnomalies: number;
 }
 
-const defaultDateRange = () => {
+const defaultFilters = (): AnalyticsFiltersValues => {
   const end = new Date();
   const start = new Date();
   start.setMonth(start.getMonth() - 1);
   return {
     startDate: start.toISOString().split("T")[0],
     endDate: end.toISOString().split("T")[0],
+    regions: [],
+    shipmentTypes: [],
   };
 };
 
 const Analytics: React.FC = () => {
+  const { announce } = useLiveRegion();
   const [metrics, setMetrics] = useState<AnalyticsMetrics>({
-    totalShipments: 0,
     onTimeRate: 0,
     avgTransitDays: 0,
     activeAnomalies: 0,
@@ -43,16 +45,19 @@ const Analytics: React.FC = () => {
   const [shipments, setShipments] = useState<Shipment[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [dateRange, setDateRange] = useState(defaultDateRange);
+  const [filters, setFilters] = useState<AnalyticsFiltersValues>(defaultFilters);
+
+  const dateRangeInvalid =
+    !!filters.startDate && !!filters.endDate && filters.startDate > filters.endDate;
 
   const fetchData = useCallback(async () => {
+    if (dateRangeInvalid) return;
     try {
       setLoading(true);
       setError(null);
 
-      const [perfData, shipData, anomData] = await Promise.all([
-        analyticsApi.getPerformance(dateRange.startDate, dateRange.endDate),
-        shipmentApi.getAll({ limit: 1 }),
+      const [perfData, anomData] = await Promise.all([
+        analyticsApi.getPerformance(filters.startDate, filters.endDate),
         anomalyApi.getAll({ limit: 1 }),
       ]);
 
@@ -68,7 +73,6 @@ const Analytics: React.FC = () => {
         ) || 1;
 
       setMetrics({
-        totalShipments: shipData.data.length,
         onTimeRate: Math.round(
           (1 - perfData.totalDelayedShipments / total) * 100,
         ),
@@ -83,7 +87,7 @@ const Analytics: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [dateRange]);
+  }, [filters.startDate, filters.endDate, dateRangeInvalid]);
 
   useEffect(() => {
     Promise.resolve().then(() => {
@@ -91,12 +95,47 @@ const Analytics: React.FC = () => {
     });
   }, [fetchData]);
 
+  // Region and shipment type aren't tracked as dedicated fields on the shipment
+  // record today, so "Region" filters by origin city and "Shipment Type" filters
+  // by the existing priority tier (URGENT/STANDARD/ECONOMY) — the closest
+  // categorical attributes available. Both apply client-side to the shipments
+  // already loaded for the selected date range; the performance/anomaly stat
+  // cards are date-range scoped only, since the backend has no region/type
+  // breakdown for those endpoints.
+  const regionOptions = useMemo(
+    () => Array.from(new Set(shipments.map((s) => s.origin))).sort(),
+    [shipments],
+  );
+
+  const filteredShipments = useMemo(() => {
+    return shipments.filter((s) => {
+      const matchesRegion =
+        filters.regions.length === 0 || filters.regions.includes(s.origin);
+      const matchesType =
+        filters.shipmentTypes.length === 0 ||
+        (s.priority ? filters.shipmentTypes.includes(s.priority) : false);
+      return matchesRegion && matchesType;
+    });
+  }, [shipments, filters.regions, filters.shipmentTypes]);
+
+  const filtersActive = filters.regions.length > 0 || filters.shipmentTypes.length > 0;
+
+  const handleFiltersChange = (next: AnalyticsFiltersValues) => {
+    setFilters(next);
+    const nextActive = next.regions.length > 0 || next.shipmentTypes.length > 0;
+    if (nextActive) {
+      announce("Analytics filters updated.");
+    } else if (filtersActive) {
+      announce("Filters cleared.");
+    }
+  };
+
   const statCards: StatCardProps[] = [
     {
       label: "Total Shipments",
-      value: metrics.totalShipments.toLocaleString(),
-      trend: `${metrics.totalShipments > 0 ? "+" : ""}${metrics.totalShipments}`,
-      trendType: metrics.totalShipments > 0 ? "up" : "neutral",
+      value: filteredShipments.length.toLocaleString(),
+      trend: `${filteredShipments.length > 0 ? "+" : ""}${filteredShipments.length}`,
+      trendType: filteredShipments.length > 0 ? "up" : "neutral",
       icon: <Package size={18} />,
     },
     {
@@ -134,28 +173,12 @@ const Analytics: React.FC = () => {
           </p>
         </div>
 
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2 bg-[#14171e] border border-[#1e293b] rounded-lg px-3 py-2">
-            <Calendar size={14} className="text-[#64748b]" />
-            <input
-              type="date"
-              value={dateRange.startDate}
-              onChange={(e) =>
-                setDateRange((prev) => ({ ...prev, startDate: e.target.value }))
-              }
-              className="bg-transparent border-none text-white text-sm outline-none w-[130px] [color-scheme:dark]"
-            />
-            <span className="text-[#64748b]">—</span>
-            <input
-              type="date"
-              value={dateRange.endDate}
-              onChange={(e) =>
-                setDateRange((prev) => ({ ...prev, endDate: e.target.value }))
-              }
-              className="bg-transparent border-none text-white text-sm outline-none w-[130px] [color-scheme:dark]"
-            />
-          </div>
-        </div>
+        <AnalyticsFilters
+          values={filters}
+          onChange={handleFiltersChange}
+          regionOptions={regionOptions}
+          disabled={loading}
+        />
       </div>
 
       {error ? (
@@ -257,8 +280,8 @@ const Analytics: React.FC = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {shipments.length > 0 ? (
-                    shipments.slice(0, 10).map((s) => (
+                  {filteredShipments.length > 0 ? (
+                    filteredShipments.slice(0, 10).map((s) => (
                       <tr key={s._id} className="group hover:bg-[rgba(255,255,255,0.02)]">
                         <td className="px-6 py-4 text-sm text-[#94a3b8] font-mono border-b border-[rgba(30,41,59,0.5)]">
                           {s.trackingNumber}
@@ -291,11 +314,25 @@ const Analytics: React.FC = () => {
                     ))
                   ) : (
                     <tr>
-                      <td
-                        colSpan={5}
-                        className="text-center px-6 py-12 text-[#64748b]"
-                      >
-                        No shipment data found for the selected period
+                      <td colSpan={5} className="px-6 py-12">
+                        <div className="flex flex-col items-center gap-2 text-center">
+                          <p className="text-[#64748b] text-sm">
+                            {filtersActive
+                              ? "No shipments match the selected filters."
+                              : "No shipment data found for the selected period."}
+                          </p>
+                          {filtersActive && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                handleFiltersChange({ ...filters, regions: [], shipmentTypes: [] })
+                              }
+                              className="text-xs text-[#3b82f6] hover:underline cursor-pointer"
+                            >
+                              Clear filters
+                            </button>
+                          )}
+                        </div>
                       </td>
                     </tr>
                   )}

--- a/frontend/src/pages/Analytics/AnalyticsFilters.tsx
+++ b/frontend/src/pages/Analytics/AnalyticsFilters.tsx
@@ -1,0 +1,236 @@
+import React, { useId, useMemo, useState } from "react";
+import { Calendar, SlidersHorizontal, X } from "lucide-react";
+
+export type ShipmentTypeFilter = "URGENT" | "STANDARD" | "ECONOMY";
+
+export interface AnalyticsFiltersValues {
+  startDate: string;
+  endDate: string;
+  regions: string[];
+  shipmentTypes: ShipmentTypeFilter[];
+}
+
+interface AnalyticsFiltersProps {
+  values: AnalyticsFiltersValues;
+  onChange: (values: AnalyticsFiltersValues) => void;
+  regionOptions: string[];
+  disabled?: boolean;
+}
+
+const SHIPMENT_TYPE_OPTIONS: { value: ShipmentTypeFilter; label: string }[] = [
+  { value: "URGENT", label: "Urgent" },
+  { value: "STANDARD", label: "Standard" },
+  { value: "ECONOMY", label: "Economy" },
+];
+
+const chipBase =
+  "inline-flex items-center gap-1.5 px-3 py-1 border rounded-full text-xs font-medium transition-all cursor-pointer";
+
+const toggleChip = (active: boolean) =>
+  `${chipBase} ${
+    active
+      ? "bg-[rgba(59,130,246,0.15)] text-[#3b82f6] border-[#3b82f6]"
+      : "bg-transparent text-[#94a3b8] border-[#1e293b] hover:border-[#3b82f6] hover:text-white"
+  }`;
+
+function countActive(f: AnalyticsFiltersValues): number {
+  let c = 0;
+  if (f.regions.length) c++;
+  if (f.shipmentTypes.length) c++;
+  return c;
+}
+
+const AnalyticsFilters: React.FC<AnalyticsFiltersProps> = ({
+  values,
+  onChange,
+  regionOptions,
+  disabled,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const panelId = useId();
+
+  const dateError = useMemo(() => {
+    if (!values.startDate || !values.endDate) return null;
+    return values.startDate > values.endDate
+      ? "Start date must be before the end date."
+      : null;
+  }, [values.startDate, values.endDate]);
+
+  const activeCount = useMemo(() => countActive(values), [values]);
+
+  const patch = (next: Partial<AnalyticsFiltersValues>) =>
+    onChange({ ...values, ...next });
+
+  const toggleRegion = (region: string) =>
+    patch({
+      regions: values.regions.includes(region)
+        ? values.regions.filter((r) => r !== region)
+        : [...values.regions, region],
+    });
+
+  const toggleShipmentType = (type: ShipmentTypeFilter) =>
+    patch({
+      shipmentTypes: values.shipmentTypes.includes(type)
+        ? values.shipmentTypes.filter((t) => t !== type)
+        : [...values.shipmentTypes, type],
+    });
+
+  const clearAll = () =>
+    onChange({ ...values, regions: [], shipmentTypes: [] });
+
+  return (
+    <div className="flex flex-col gap-3 w-full md:w-auto">
+      <div className="flex items-center gap-3 flex-wrap max-md:flex-col max-md:items-stretch">
+        <div className="flex items-center gap-2 bg-[#14171e] border border-[#1e293b] rounded-lg px-3 py-2">
+          <Calendar size={14} className="text-[#64748b]" aria-hidden="true" />
+          <label className="sr-only" htmlFor="analytics-start-date">
+            Start date
+          </label>
+          <input
+            id="analytics-start-date"
+            type="date"
+            value={values.startDate}
+            max={values.endDate || undefined}
+            disabled={disabled}
+            onChange={(e) => patch({ startDate: e.target.value })}
+            className="bg-transparent border-none text-white text-sm outline-none w-[130px] [color-scheme:dark] disabled:opacity-50"
+            aria-invalid={!!dateError}
+            aria-describedby={dateError ? "analytics-date-error" : undefined}
+          />
+          <span className="text-[#64748b]" aria-hidden="true">
+            —
+          </span>
+          <label className="sr-only" htmlFor="analytics-end-date">
+            End date
+          </label>
+          <input
+            id="analytics-end-date"
+            type="date"
+            value={values.endDate}
+            min={values.startDate || undefined}
+            disabled={disabled}
+            onChange={(e) => patch({ endDate: e.target.value })}
+            className="bg-transparent border-none text-white text-sm outline-none w-[130px] [color-scheme:dark] disabled:opacity-50"
+            aria-invalid={!!dateError}
+            aria-describedby={dateError ? "analytics-date-error" : undefined}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setIsOpen((o) => !o)}
+          aria-expanded={isOpen}
+          aria-controls={panelId}
+          className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer border ${
+            isOpen || activeCount > 0
+              ? "bg-[rgba(59,130,246,0.1)] border-[#3b82f6] text-[#3b82f6]"
+              : "bg-[#14171e] border-[#1e293b] text-[#94a3b8] hover:text-white hover:border-[#3b82f6]"
+          }`}
+        >
+          <SlidersHorizontal size={14} aria-hidden="true" />
+          Filters
+          {activeCount > 0 && (
+            <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold">
+              {activeCount}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {dateError && (
+        <p id="analytics-date-error" role="alert" className="text-xs text-[#ef4444]">
+          {dateError}
+        </p>
+      )}
+
+      {activeCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2" aria-label="Active filters">
+          {values.regions.length > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-[rgba(59,130,246,0.08)] border border-[rgba(59,130,246,0.3)] rounded-full text-xs text-[#3b82f6] font-medium">
+              Region: {values.regions.join(", ")}
+              <button
+                type="button"
+                onClick={() => patch({ regions: [] })}
+                className="w-3.5 h-3.5 flex items-center justify-center rounded-full hover:bg-[rgba(255,255,255,0.15)] hover:text-white transition-colors"
+                aria-label="Remove region filter"
+              >
+                <X size={10} />
+              </button>
+            </span>
+          )}
+          {values.shipmentTypes.length > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-[rgba(59,130,246,0.08)] border border-[rgba(59,130,246,0.3)] rounded-full text-xs text-[#3b82f6] font-medium">
+              Type: {values.shipmentTypes.map((t) => t.charAt(0) + t.slice(1).toLowerCase()).join(", ")}
+              <button
+                type="button"
+                onClick={() => patch({ shipmentTypes: [] })}
+                className="w-3.5 h-3.5 flex items-center justify-center rounded-full hover:bg-[rgba(255,255,255,0.15)] hover:text-white transition-colors"
+                aria-label="Remove shipment type filter"
+              >
+                <X size={10} />
+              </button>
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={clearAll}
+            className="px-3 py-1 text-xs text-[#64748b] hover:text-white transition-colors"
+          >
+            Clear All
+          </button>
+        </div>
+      )}
+
+      {isOpen && (
+        <div
+          id={panelId}
+          className="p-4 bg-[#14171e] border border-[#1e293b] rounded-xl grid grid-cols-1 md:grid-cols-2 gap-4"
+        >
+          <div>
+            <span className="block text-xs text-[#64748b] mb-2 font-medium uppercase tracking-wider">
+              Region
+            </span>
+            {regionOptions.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {regionOptions.map((region) => (
+                  <label key={region} className={toggleChip(values.regions.includes(region))}>
+                    <input
+                      type="checkbox"
+                      checked={values.regions.includes(region)}
+                      onChange={() => toggleRegion(region)}
+                      className="sr-only"
+                    />
+                    {region}
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-[#64748b]">No regions available for the selected period.</p>
+            )}
+          </div>
+
+          <div>
+            <span className="block text-xs text-[#64748b] mb-2 font-medium uppercase tracking-wider">
+              Shipment Type
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {SHIPMENT_TYPE_OPTIONS.map(({ value, label }) => (
+                <label key={value} className={toggleChip(values.shipmentTypes.includes(value))}>
+                  <input
+                    type="checkbox"
+                    checked={values.shipmentTypes.includes(value)}
+                    onChange={() => toggleShipmentType(value)}
+                    className="sr-only"
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AnalyticsFilters;

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -10,6 +10,9 @@ export const apiClient = axios.create({
         "Content-Type": "application/json",
     },
     withCredentials: true,
+    // Safety net so a stalled connection fails with a recoverable error
+    // instead of hanging the UI in a loading state indefinitely.
+    timeout: 30000,
 });
 
 // Intercept requests to guard against missing base URL at runtime

--- a/frontend/src/services/api/interceptors/errorInterceptor.ts
+++ b/frontend/src/services/api/interceptors/errorInterceptor.ts
@@ -10,6 +10,23 @@ export const setupErrorInterceptor = (client: AxiosInstance, navigateFn?: (path:
         (error: AxiosError) => {
             const status = error.response?.status;
 
+            // Requests that never got a response (offline, DNS/connection failure,
+            // or our own client-side timeout) don't have a status code. Surface
+            // those distinctly instead of silently failing with only a console log.
+            // The shared toast `id` collapses repeat failures (e.g. several
+            // in-flight requests dropping at once) into a single toast instead of
+            // stacking one per request.
+            if (!error.response) {
+                const message =
+                    error.code === "ECONNABORTED"
+                        ? "Request timed out. Check your connection and try again."
+                        : typeof navigator !== "undefined" && !navigator.onLine
+                            ? "You're offline. This action didn't go through."
+                            : "Network error — please check your connection and try again.";
+                toast.error(message, { id: "network-error" });
+                return Promise.reject(error);
+            }
+
             switch (status) {
                 case 401:
                     if (!isRedirecting) {


### PR DESCRIPTION
## Summary

**#499 — Analytics filters (date range, region, shipment type)**
- Added `AnalyticsFilters` to the Analytics page: date range (with inline validation for start > end), region, and shipment type.
- The shipment record has no dedicated `region` or `shipmentType` field today, so as a documented assumption: **region filters by shipment origin city**, and **shipment type filters by the existing `priority` tier** (URGENT/STANDARD/ECONOMY) — the closest available categorical attributes.
- Filters apply client-side to the stat cards and Recent Shipments table (the performance/anomaly stat cards stay date-range scoped, since the backend has no region/type breakdown for those endpoints).
- Active-filter chips with individual remove + "Clear All", a distinct empty state when filters exclude all rows, and full keyboard/screen-reader support.
- Removed a now-dead `totalShipments` fetch (`shipmentApi.getAll({ limit: 1 })`) that was superseded by the filtered count.

**#497 — Slow network and offline handling**
- `apiClient` now has a 30s timeout so a stalled request fails with a recoverable error instead of hanging the UI in a loading state forever.
- `errorInterceptor` surfaces network-level failures (timeout, offline, unreachable host) that previously only hit `console.error` with no user-facing feedback. Failures are deduped via a shared toast id so several in-flight requests dropping at once don't stack toasts.
- Mounted react-hot-toast's `<Toaster/>` in `App.tsx` — it was never rendered anywhere, so the existing `toast.error` calls in `errorInterceptor` (401/403/500) were already silently no-ops. This was a prerequisite for any of the new feedback to actually reach the user.
- `OfflineBanner` now confirms recovery with a "You're back online" toast instead of silently disappearing.
- New `SlowConnectionBanner` + `useSlowConnection` hook give a best-effort, dismissible warning when the Network Information API reports a slow connection (slow-2g/2g). Gracefully no-ops in browsers that don't support the API (Safari/Firefox).

## Test plan
- [x] `tsc -b` — no new type errors (2 pre-existing unrelated errors in `StatusUpdate.tsx` / `Shipments.tsx` predate this branch)
- [x] `eslint` on all touched files — clean
- [ ] Manual verification in a running app (not performed in this session)

Closes #499
Closes #497
Closes #495 
Closes #496
🤖 Generated with [Claude Code](https://claude.com/claude-code)