### PR TITLE
feat: add route-based widget cache and stale-data handling (#549)

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -27,6 +27,8 @@ export { default as Tag } from './ui/Tag';
 export type { TagProps } from './ui/Tag';
 export { default as MultiSelect } from './ui/MultiSelect';
 export type { MultiSelectOption, MultiSelectProps } from './ui/MultiSelect';
+export { default as StaleDataBanner } from './ui/StaleDataBanner';
+export type { StaleDataBannerProps } from './ui/StaleDataBanner';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
 
 export { default as Card, CardHeader, CardBody, CardFooter } from './Card';

--- a/frontend/src/components/ui/StaleDataBanner.tsx
+++ b/frontend/src/components/ui/StaleDataBanner.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { RefreshCw, X } from 'lucide-react';
+
+export interface StaleDataBannerProps {
+  /** Whether the data is currently stale */
+  isStale: boolean;
+  /** Timestamp of the most recent data fetch */
+  lastUpdated: Date | null;
+  /** Callback invoked when the user clicks "Refresh" */
+  onRefresh: () => void;
+}
+
+/**
+ * A subtle, dismissible banner indicating that data is stale.
+ * Shown at the top of a widget or page when `isStale` is `true`.
+ *
+ * Features:
+ * - Displays last updated time
+ * - "Refresh" button to re-fetch
+ * - Dismissible with a close (X) button
+ * - Accessible with proper aria-live region
+ */
+const StaleDataBanner: React.FC<StaleDataBannerProps> = ({ isStale, lastUpdated, onRefresh }) => {
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  // If not stale or user dismissed it, hide the banner.
+  if (!isStale || isDismissed) return null;
+
+  const formattedTime = lastUpdated
+    ? lastUpdated.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    : 'Unknown';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-yellow-700 bg-yellow-950/30 px-4 py-2.5 text-sm text-yellow-200"
+    >
+      <div className="flex items-center gap-2">
+        <RefreshCw size={16} className="text-yellow-400" aria-hidden="true" />
+        <span>
+          Data may be outdated. Last updated: <strong>{formattedTime}</strong>
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onRefresh}
+          aria-label="Refresh data"
+          className="inline-flex items-center gap-1.5 rounded bg-yellow-600 px-3 py-1 text-xs font-semibold text-white transition-colors hover:bg-yellow-500 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-yellow-950"
+        >
+          <RefreshCw size={14} aria-hidden="true" />
+          Refresh
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setIsDismissed(true)}
+          aria-label="Dismiss stale data notice"
+          className="inline-flex h-6 w-6 items-center justify-center rounded text-yellow-300 transition-colors hover:bg-yellow-900/50 hover:text-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 focus:ring-offset-yellow-950"
+        >
+          <X size={16} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StaleDataBanner;

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -5,3 +5,5 @@ export { useFocusTrap } from './useFocusTrap';
 export { useScrollSpy } from './useScrollSpy';
 export { useBulkSelection } from './useBulkSelection';
 export type { UseBulkSelectionReturn } from './useBulkSelection';
+export { default as useWidgetCache } from './useWidgetCache';
+export type { UseWidgetCacheOptions, UseWidgetCacheReturn } from './useWidgetCache';

--- a/frontend/src/hooks/useWidgetCache.ts
+++ b/frontend/src/hooks/useWidgetCache.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Module-level cache — shared across all hook instances within the session.
+// Key format: "<routePath>@@<widgetKey>"
+// ---------------------------------------------------------------------------
+
+interface CacheEntry<T> {
+  data: T;
+  fetchedAt: number; // epoch ms
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const widgetCacheMap = new Map<string, CacheEntry<any>>();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseWidgetCacheOptions {
+  /** Time-to-live in milliseconds before cached data is considered stale. Default: 30 000 ms */
+  ttlMs?: number;
+}
+
+export interface UseWidgetCacheReturn<T> {
+  /** The fetched (or cached) data, or `null` while loading for the first time */
+  data: T | null;
+  /** True while a fetch is in flight */
+  isLoading: boolean;
+  /** True when cached data exists but is older than `ttlMs` */
+  isStale: boolean;
+  /** Timestamp of the most recent successful fetch, or `null` before first fetch */
+  lastUpdated: Date | null;
+  /** Force a fresh fetch regardless of TTL */
+  refresh: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Route-aware, TTL-based cache for dashboard widget data.
+ *
+ * - Cache is keyed by both the widget `key` and the current route path so
+ *   each route maintains its own independent cache entry.
+ * - On mount (or route re-visit) the hook checks the TTL:
+ *   - Fresh data → returned immediately, no loading state triggered.
+ *   - Stale/missing data → fetch is triggered automatically.
+ * - `refresh()` forces a re-fetch and updates the cache.
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, isStale, refresh, lastUpdated } =
+ *   useWidgetCache('shipment-stats', fetchShipmentStats, { ttlMs: 60_000 });
+ * ```
+ */
+function useWidgetCache<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  options?: UseWidgetCacheOptions,
+): UseWidgetCacheReturn<T> {
+  const { pathname } = useLocation();
+  const ttlMs = options?.ttlMs ?? 30_000;
+
+  // Stable cache key that combines route + widget key
+  const cacheKey = `${pathname}@@${key}`;
+
+  // Keep a ref so the effect closure always sees the latest fetcher without
+  // adding it to the dependency array (avoids infinite loops when the caller
+  // passes an inline arrow function).
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  // -------------------------------------------------------------------------
+  // Derive initial state from whatever is already in the cache.
+  // -------------------------------------------------------------------------
+  const getCachedEntry = useCallback((): CacheEntry<T> | undefined => {
+    return widgetCacheMap.get(cacheKey) as CacheEntry<T> | undefined;
+  }, [cacheKey]);
+
+  const isEntryStale = useCallback(
+    (entry: CacheEntry<T>): boolean => {
+      return Date.now() - entry.fetchedAt > ttlMs;
+    },
+    [ttlMs],
+  );
+
+  const initialEntry = getCachedEntry();
+  const initialIsStale = initialEntry ? isEntryStale(initialEntry) : false;
+
+  const [data, setData] = useState<T | null>(initialEntry?.data ?? null);
+  const [isLoading, setIsLoading] = useState<boolean>(
+    // Only show loading on first load; fresh cached data skips the spinner.
+    !initialEntry || initialIsStale,
+  );
+  const [isStale, setIsStale] = useState<boolean>(initialIsStale);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(
+    initialEntry ? new Date(initialEntry.fetchedAt) : null,
+  );
+
+  // -------------------------------------------------------------------------
+  // Core fetch logic
+  // -------------------------------------------------------------------------
+  const runFetch = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const result = await fetcherRef.current();
+      const fetchedAt = Date.now();
+      widgetCacheMap.set(cacheKey, { data: result, fetchedAt });
+      setData(result);
+      setLastUpdated(new Date(fetchedAt));
+      setIsStale(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [cacheKey]);
+
+  // -------------------------------------------------------------------------
+  // Effect: run on mount and whenever the cache key changes (i.e., route
+  // navigation returns to this widget's route).
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    const entry = getCachedEntry();
+
+    if (!entry) {
+      // No cached data at all — fetch immediately.
+      void runFetch();
+      return;
+    }
+
+    if (isEntryStale(entry)) {
+      // Data exists but is past TTL — mark stale and re-fetch.
+      setData(entry.data); // keep showing stale data while re-fetching
+      setIsStale(true);
+      void runFetch();
+    } else {
+      // Fresh cached data — hydrate state without a loading spinner.
+      setData(entry.data);
+      setIsStale(false);
+      setLastUpdated(new Date(entry.fetchedAt));
+      setIsLoading(false);
+    }
+  }, [cacheKey, getCachedEntry, isEntryStale, runFetch]);
+
+  // -------------------------------------------------------------------------
+  // Public refresh — invalidates the entry and forces a re-fetch.
+  // -------------------------------------------------------------------------
+  const refresh = useCallback(() => {
+    widgetCacheMap.delete(cacheKey);
+    void runFetch();
+  }, [cacheKey, runFetch]);
+
+  return { data, isLoading, isStale, refresh, lastUpdated };
+}
+
+export default useWidgetCache;


### PR DESCRIPTION
- Add useWidgetCache hook with TTL-based stale detection and route-aware cache keys
- Cache is keyed by both widget key and current route path (useLocation)
- Returns data, isLoading, isStale, lastUpdated, and refresh function
- Fresh cached data is returned immediately without a loading spinner
- Stale data is shown while re-fetching in the background
- Add StaleDataBanner component for displaying stale data warnings
- StaleDataBanner is dismissible, has a Refresh button, and uses aria-live
- Export useWidgetCache from hooks/index.ts
- Export StaleDataBanner from components/index.ts

## Issue
Closes #

## Description
<!-- Brief summary of what you built or fixed -->

## Testing
<!-- How you verified it works - list what you tested -->
- [ ] Ran `pnpm run lint` (no errors)
- [ ] Ran `pnpm run build` (builds successfully)
- [ ] Ran `pnpm run test` (all tests pass)
- [ ] Tested in browser (describe what you tested)

## Screenshots/Recording
<!-- **REQUIRED for all frontend PRs** - attach screenshots or screen recording -->

## Checklist
- [ ] My PR targets the `dev` branch (not `main`)
- [ ] My branch is up-to-date with `dev`
- [ ] I followed the code standards in CONTRIBUTING.md
- [ ] I added/updated tests if needed
- [ ] All CI checks pass

   Closes #549 
