### PR TITLE
feat: add overdue and at-risk shipment highlighting (#550)

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -65,6 +65,8 @@ export { default as StatusUpdate } from './shipment/StatusUpdate';
 export type { StatusUpdateProps, ShipmentMilestone } from './shipment/StatusUpdate';
 export { default as DeliveryConfirmation } from './shipment/DeliveryConfirmation/DeliveryConfirmation';
 export type { DeliveryConfirmationProps } from './shipment/DeliveryConfirmation/DeliveryConfirmation';
+export { default as OverdueShipmentBadge } from './shipment/OverdueShipmentBadge';
+export type { OverdueShipmentBadgeProps } from './shipment/OverdueShipmentBadge';
 
 // Onboarding
 export { OnboardingTour } from './onboarding';

--- a/frontend/src/components/shipment/OverdueShipmentBadge/OverdueShipmentBadge.tsx
+++ b/frontend/src/components/shipment/OverdueShipmentBadge/OverdueShipmentBadge.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import type { RiskLevel } from '../../../utils/shipmentRisk';
+
+export interface OverdueShipmentBadgeProps {
+  level: RiskLevel;
+  daysOverdue?: number;
+}
+
+const STYLES: Record<Exclude<RiskLevel, 'normal'>, string> = {
+  overdue:
+    'bg-red-500/15 text-red-400 border border-red-500/30',
+  'at-risk':
+    'bg-amber-400/15 text-amber-400 border border-amber-400/30',
+};
+
+const LABELS: Record<Exclude<RiskLevel, 'normal'>, string> = {
+  overdue: 'Overdue',
+  'at-risk': 'At Risk',
+};
+
+/**
+ * A small badge that visually flags overdue or at-risk shipments.
+ * Returns null for shipments with `normal` risk level.
+ */
+const OverdueShipmentBadge: React.FC<OverdueShipmentBadgeProps> = ({
+  level,
+  daysOverdue,
+}) => {
+  if (level === 'normal') return null;
+
+  const label =
+    level === 'overdue' && daysOverdue !== undefined && daysOverdue > 0
+      ? `Overdue by ${daysOverdue}d`
+      : LABELS[level];
+
+  const ariaLabel =
+    level === 'overdue' && daysOverdue !== undefined && daysOverdue > 0
+      ? `Shipment is overdue by ${daysOverdue} day${daysOverdue === 1 ? '' : 's'}`
+      : level === 'overdue'
+        ? 'Shipment is overdue'
+        : 'Shipment is at risk of being late';
+
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold uppercase tracking-wide ${STYLES[level]}`}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default OverdueShipmentBadge;

--- a/frontend/src/components/shipment/OverdueShipmentBadge/index.ts
+++ b/frontend/src/components/shipment/OverdueShipmentBadge/index.ts
@@ -1,0 +1,2 @@
+export { default as OverdueShipmentBadge } from './OverdueShipmentBadge';
+export type { OverdueShipmentBadgeProps } from './OverdueShipmentBadge';

--- a/frontend/src/pages/Shipments/Shipments.tsx
+++ b/frontend/src/pages/Shipments/Shipments.tsx
@@ -11,6 +11,11 @@ import { BulkStatusModal } from "../../components/shipment/BulkStatusModal";
 import { useBulkSelection } from "../../hooks/useBulkSelection";
 import { useToast } from "../../context/ToastContext";
 import { safeFormatDate } from "../../utils/safeFormat";
+import {
+  getShipmentRiskLevel,
+  getShipmentRiskStyle,
+} from "../../utils/shipmentRisk";
+import OverdueShipmentBadge from "../../components/shipment/OverdueShipmentBadge/OverdueShipmentBadge";
 import { useVirtualShipments } from "./hooks/useVirtualShipments";
 import ShipmentsKanban from "./KanbanView/ShipmentsKanban";
 import RouteMap from "./RouteMap/RouteMap";
@@ -561,12 +566,15 @@ const Shipments: React.FC = () => {
                       const shipment = filteredShipments[virtualRow.index];
                       if (!shipment) return null;
                       const selected = isSelected(shipment.id);
+                      const riskInfo = getShipmentRiskLevel(shipment);
+                      const riskStyle = getShipmentRiskStyle(riskInfo.level);
                       return (
                         <tr
                           key={virtualRow.key}
                           data-index={virtualRow.index}
                           ref={virtualizer.measureElement}
                           aria-selected={selected}
+                          className={riskStyle}
                           style={{
                             position: "absolute",
                             top: 0,
@@ -589,7 +597,17 @@ const Shipments: React.FC = () => {
                               className="cursor-pointer accent-[#62ffff] w-4 h-4"
                             />
                           </td>
-                          <td>{shipment.id}</td>
+                          <td>
+                            <span className="inline-flex items-center gap-1.5 flex-wrap">
+                              {shipment.id}
+                              {riskInfo.level !== "normal" && (
+                                <OverdueShipmentBadge
+                                  level={riskInfo.level}
+                                  daysOverdue={riskInfo.daysOverdue}
+                                />
+                              )}
+                            </span>
+                          </td>
                           <td>{shipment.origin}</td>
                           <td>{shipment.destination}</td>
                           <td>

--- a/frontend/src/utils/shipmentRisk.ts
+++ b/frontend/src/utils/shipmentRisk.ts
@@ -1,0 +1,69 @@
+import type { Shipment } from '../api/shipmentApi';
+
+export type RiskLevel = 'overdue' | 'at-risk' | 'normal';
+
+export interface ShipmentRiskInfo {
+  level: RiskLevel;
+  label: string;
+  daysOverdue?: number;
+}
+
+/**
+ * Returns how many days have elapsed since `createdAt`.
+ */
+function daysSinceCreated(createdAt: string): number {
+  const created = new Date(createdAt).getTime();
+  const now = Date.now();
+  return Math.floor((now - created) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Computes the risk level for a shipment:
+ * - `overdue`  : IN_TRANSIT and older than 14 days (no delivery = late)
+ * - `at-risk`  : IN_TRANSIT and 10–14 days old, OR URGENT and not DELIVERED/CANCELLED
+ * - `normal`   : everything else
+ */
+export function getShipmentRiskLevel(shipment: Shipment): ShipmentRiskInfo {
+  const { status, priority, createdAt } = shipment;
+  const days = daysSinceCreated(createdAt);
+
+  if (status === 'IN_TRANSIT' && days > 14) {
+    return {
+      level: 'overdue',
+      label: 'Overdue',
+      daysOverdue: days - 14,
+    };
+  }
+
+  if (
+    (status === 'IN_TRANSIT' && days >= 10 && days <= 14) ||
+    (priority === 'URGENT' && status !== 'DELIVERED' && status !== 'CANCELLED')
+  ) {
+    return {
+      level: 'at-risk',
+      label: 'At Risk',
+    };
+  }
+
+  return {
+    level: 'normal',
+    label: '',
+  };
+}
+
+/**
+ * Returns Tailwind class strings to highlight a table row or card
+ * based on the shipment's risk level.
+ */
+export function getShipmentRiskStyle(level: RiskLevel): string {
+  switch (level) {
+    case 'overdue':
+      // Red left border + subtle red background tint
+      return 'border-l-4 border-l-red-500 bg-red-500/5';
+    case 'at-risk':
+      // Amber left border + subtle amber background tint
+      return 'border-l-4 border-l-amber-400 bg-amber-400/5';
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
- Add getShipmentRiskLevel utility: classifies shipments as overdue (>14 days IN_TRANSIT), at-risk (10-14 days IN_TRANSIT or URGENT not yet delivered), or normal
- Add getShipmentRiskStyle utility: returns Tailwind classes for row highlighting (red left border + tint for overdue, amber for at-risk)
- Add OverdueShipmentBadge component: accessible chip badge showing 'Overdue by Xd' or 'At Risk' with role=status and aria-label
- Update Shipments list view to apply row highlighting and show badge next to tracking ID
- Export OverdueShipmentBadge from components/index.ts

## Issue
Closes #

## Description
<!-- Brief summary of what you built or fixed -->

## Testing
<!-- How you verified it works - list what you tested -->
- [ ] Ran `pnpm run lint` (no errors)
- [ ] Ran `pnpm run build` (builds successfully)
- [ ] Ran `pnpm run test` (all tests pass)
- [ ] Tested in browser (describe what you tested)

## Screenshots/Recording
<!-- **REQUIRED for all frontend PRs** - attach screenshots or screen recording -->

## Checklist
- [ ] My PR targets the `dev` branch (not `main`)
- [ ] My branch is up-to-date with `dev`
- [ ] I followed the code standards in CONTRIBUTING.md
- [ ] I added/updated tests if needed
- [ ] All CI checks pass
 
   Closes #550 