### PR TITLE
feat: progress stepper, notification preferences, shipment grid view …

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -35,4 +35,12 @@ dist-ssr
 vite.config.js
 vite.config.ts.timestamp-*
 
+# Test snapshots and coverage
+**/__snapshots__/
+coverage/
+.nyc_output/
+test-results/
+playwright-report/
+html/
+
 # Somzilla issues document (root-level .gitignore handles this)

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -17,6 +17,8 @@ export type { ColumnDef as DataTableUIColumnDef, DataTableProps as DataTableUIPr
 // UI
 export { ProgressBar } from './ui/ProgressBar';
 export type { ProgressBarProps, ProgressBarColor, ProgressBarSize } from './ui/ProgressBar';
+export { ProgressStepper } from './ui/ProgressStepper';
+export type { ProgressStepperProps, StepDef } from './ui/ProgressStepper';
 export { CircularProgress } from './ui/CircularProgress';
 export type { CircularProgressProps } from './ui/CircularProgress';
 export { default as Avatar } from './ui/Avatar';

--- a/frontend/src/components/ui/ProgressStepper/ProgressStepper.tsx
+++ b/frontend/src/components/ui/ProgressStepper/ProgressStepper.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Check } from 'lucide-react';
+
+export interface StepDef {
+  label: string;
+  description?: string;
+}
+
+export interface ProgressStepperProps {
+  steps: StepDef[];
+  currentStep: number; // 1-indexed
+  className?: string;
+}
+
+const ProgressStepper: React.FC<ProgressStepperProps> = ({
+  steps,
+  currentStep,
+  className = '',
+}) => {
+  return (
+    <nav
+      aria-label="Progress steps"
+      className={`flex items-center justify-center ${className}`}
+    >
+      {steps.map((step, index) => {
+        const stepNumber = index + 1;
+        const isCompleted = currentStep > stepNumber;
+        const isActive = currentStep === stepNumber;
+        const isLast = index === steps.length - 1;
+
+        return (
+          <React.Fragment key={stepNumber}>
+            {/* Step node */}
+            <div className="flex flex-col items-center gap-1.5">
+              {/* Circle */}
+              <div
+                className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold transition-all duration-300 ${
+                  isActive
+                    ? 'bg-[#00DAC1] text-black shadow-[0_0_0_4px_rgba(0,218,193,0.2)]'
+                    : isCompleted
+                    ? 'bg-[rgba(0,218,193,0.15)] border-2 border-[#00DAC1] text-[#00DAC1]'
+                    : 'bg-[rgba(255,255,255,0.05)] border-2 border-[rgba(255,255,255,0.15)] text-[rgba(255,255,255,0.35)]'
+                }`}
+                aria-current={isActive ? 'step' : undefined}
+              >
+                {isCompleted ? (
+                  <Check size={16} aria-hidden="true" />
+                ) : (
+                  <span>{stepNumber}</span>
+                )}
+              </div>
+
+              {/* Label */}
+              <span
+                className={`text-[0.7rem] font-medium text-center max-w-[72px] leading-tight transition-colors duration-300 ${
+                  isActive
+                    ? 'text-[#00DAC1]'
+                    : isCompleted
+                    ? 'text-[#00DAC1]/70'
+                    : 'text-[rgba(255,255,255,0.3)]'
+                }`}
+              >
+                {step.label}
+              </span>
+
+              {/* Description (optional, shown below label for active step) */}
+              {isActive && step.description && (
+                <span className="text-[0.65rem] text-[rgba(255,255,255,0.45)] text-center max-w-[80px] leading-tight">
+                  {step.description}
+                </span>
+              )}
+            </div>
+
+            {/* Connector line */}
+            {!isLast && (
+              <div
+                className={`h-px flex-1 mx-2 mb-5 transition-all duration-500 ${
+                  isCompleted ? 'bg-[#00DAC1]' : 'bg-[rgba(255,255,255,0.1)]'
+                }`}
+                aria-hidden="true"
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default ProgressStepper;

--- a/frontend/src/components/ui/ProgressStepper/index.ts
+++ b/frontend/src/components/ui/ProgressStepper/index.ts
@@ -1,0 +1,2 @@
+export { default as ProgressStepper } from './ProgressStepper';
+export type { ProgressStepperProps, StepDef } from './ProgressStepper';

--- a/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.tsx
+++ b/frontend/src/pages/Settings/NotificationPreferences/NotificationPreferences.tsx
@@ -1,14 +1,23 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Bell, CheckCircle2, Loader2 } from 'lucide-react';
+import { Bell, CheckCircle2, Loader2, Smartphone } from 'lucide-react';
 import {
   type NotificationChannel,
   type NotificationEventType,
   type PreferencesMap,
   notificationPreferencesApi,
 } from '@services/api/endpoints/notifications';
-import './NotificationPreferences.css';
 
-// ---------- Data ----------
+// ---------- Types ----------
+
+type ExtendedChannel = NotificationChannel | 'push';
+
+interface ExtendedPreference {
+  email: boolean;
+  sms: boolean;
+  push: boolean;
+}
+
+type ExtendedPreferencesMap = Record<NotificationEventType, ExtendedPreference>;
 
 interface EventDef {
   event: NotificationEventType;
@@ -19,6 +28,8 @@ interface CategoryDef {
   label: string;
   events: EventDef[];
 }
+
+// ---------- Data ----------
 
 const CATEGORIES: CategoryDef[] = [
   {
@@ -44,16 +55,75 @@ const CATEGORIES: CategoryDef[] = [
 
 const ALL_EVENTS = CATEGORIES.flatMap((c) => c.events.map((e) => e.event));
 
-const defaultPreferences = (): PreferencesMap =>
-  Object.fromEntries(ALL_EVENTS.map((e) => [e, { email: false, sms: false }])) as PreferencesMap;
+const defaultPreferences = (): ExtendedPreferencesMap =>
+  Object.fromEntries(
+    ALL_EVENTS.map((e) => [e, { email: false, sms: false, push: false }]),
+  ) as ExtendedPreferencesMap;
 
-// ---------- Component ----------
+// ---------- Toggle component ----------
+
+interface ToggleSwitchProps {
+  id: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: () => void;
+  ariaLabel: string;
+  title?: string;
+}
+
+const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
+  id,
+  checked,
+  disabled = false,
+  onChange,
+  ariaLabel,
+  title,
+}) => (
+  <label
+    htmlFor={id}
+    title={title}
+    className={`relative inline-block w-11 h-6 flex-shrink-0 ${
+      disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
+    }`}
+  >
+    <input
+      id={id}
+      type="checkbox"
+      className="sr-only"
+      checked={checked}
+      onChange={onChange}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      aria-disabled={disabled}
+    />
+    <span
+      className={`absolute inset-0 rounded-full border transition-colors duration-300 ${
+        checked
+          ? 'bg-[rgba(59,130,246,0.15)] border-[#3B82F6]'
+          : 'bg-[#1E293B] border-[#334155]'
+      }`}
+    />
+    <span
+      className={`absolute top-[3px] left-[3px] w-[18px] h-[18px] rounded-full transition-all duration-300 ${
+        checked
+          ? 'translate-x-5 bg-[#3B82F6]'
+          : 'translate-x-0 bg-[#94A3B8]'
+      }`}
+    />
+  </label>
+);
+
+// ---------- Main Component ----------
 
 const NotificationPreferences: React.FC = () => {
-  const [prefs, setPrefs] = useState<PreferencesMap>(defaultPreferences);
+  const [prefs, setPrefs] = useState<ExtendedPreferencesMap>(defaultPreferences);
   const [loadingInitial, setLoadingInitial] = useState(true);
   const [savedEvent, setSavedEvent] = useState<NotificationEventType | null>(null);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Push notification permission state
+  const [pushEnabled, setPushEnabled] = useState(false);
+  const [pushRequesting, setPushRequesting] = useState(false);
 
   // Phone verification state
   const [phone, setPhone] = useState('');
@@ -67,7 +137,16 @@ const NotificationPreferences: React.FC = () => {
   useEffect(() => {
     notificationPreferencesApi
       .getPreferences()
-      .then((data) => setPrefs(data))
+      .then((data) => {
+        // Merge API response (email/sms) into extended map with push defaulting to false
+        setPrefs((prev) => {
+          const merged = { ...prev };
+          (Object.keys(data) as NotificationEventType[]).forEach((evt) => {
+            merged[evt] = { ...merged[evt], email: data[evt].email, sms: data[evt].sms };
+          });
+          return merged;
+        });
+      })
       .catch(() => {/* keep defaults on error */})
       .finally(() => setLoadingInitial(false));
   }, []);
@@ -78,19 +157,67 @@ const NotificationPreferences: React.FC = () => {
     savedTimerRef.current = setTimeout(() => setSavedEvent(null), 2500);
   }, []);
 
-  const handleToggle = async (event: NotificationEventType, channel: NotificationChannel) => {
+  const handleToggle = async (event: NotificationEventType, channel: ExtendedChannel) => {
     const prev = prefs[event][channel];
     const next = !prev;
 
     // Optimistic update
     setPrefs((p) => ({ ...p, [event]: { ...p[event], [channel]: next } }));
 
+    if (channel === 'push') {
+      // Push is local-only — no API call needed until push service is integrated
+      showSaved(event);
+      return;
+    }
+
     try {
-      await notificationPreferencesApi.updatePreference(event, channel, next);
+      await notificationPreferencesApi.updatePreference(event, channel as NotificationChannel, next);
       showSaved(event);
     } catch {
       // Roll back
       setPrefs((p) => ({ ...p, [event]: { ...p[event], [channel]: prev } }));
+    }
+  };
+
+  // Category-level bulk toggle: sets all events in category to the same value for a channel
+  const handleCategoryBulkToggle = async (
+    category: CategoryDef,
+    channel: ExtendedChannel,
+    value: boolean,
+  ) => {
+    const events = category.events.map((e) => e.event);
+
+    // Optimistic update
+    setPrefs((p) => {
+      const updated = { ...p };
+      events.forEach((evt) => {
+        updated[evt] = { ...updated[evt], [channel]: value };
+      });
+      return updated;
+    });
+
+    if (channel === 'push') return;
+
+    // Fire API calls in parallel
+    await Promise.allSettled(
+      events.map((evt) =>
+        notificationPreferencesApi.updatePreference(
+          evt,
+          channel as NotificationChannel,
+          value,
+        ),
+      ),
+    );
+  };
+
+  const handleRequestPush = async () => {
+    if (!('Notification' in window)) return;
+    setPushRequesting(true);
+    try {
+      const permission = await Notification.requestPermission();
+      setPushEnabled(permission === 'granted');
+    } finally {
+      setPushRequesting(false);
     }
   };
 
@@ -130,45 +257,74 @@ const NotificationPreferences: React.FC = () => {
     }
   };
 
+  // Check if all events in a category have a given channel enabled
+  const isCategoryFullyEnabled = (category: CategoryDef, channel: ExtendedChannel) =>
+    category.events.every((e) => prefs[e.event]?.[channel] === true);
+
+  const isCategoryPartiallyEnabled = (category: CategoryDef, channel: ExtendedChannel) =>
+    category.events.some((e) => prefs[e.event]?.[channel] === true) &&
+    !isCategoryFullyEnabled(category, channel);
+
   if (loadingInitial) {
     return (
-      <section className="notif-pref-container notif-pref-loading" aria-label="Loading notification preferences">
-        <Loader2 className="notif-spinner" size={24} />
+      <section
+        className="flex items-center justify-center gap-3 p-12 bg-[#14171E] border border-[#1E293B] rounded-xl text-slate-500 text-sm"
+        aria-label="Loading notification preferences"
+      >
+        <Loader2 className="animate-spin" size={20} />
         <span>Loading preferences…</span>
       </section>
     );
   }
 
+  const CHANNELS: { key: ExtendedChannel; label: string }[] = [
+    { key: 'email', label: 'Email' },
+    { key: 'sms', label: 'SMS' },
+    { key: 'push', label: 'Push' },
+  ];
+
   return (
-    <section className="notif-pref-container" aria-labelledby="notification-preferences-title">
+    <section
+      className="w-full bg-[#14171E] border border-[#1E293B] rounded-xl overflow-hidden"
+      aria-labelledby="notification-preferences-title"
+    >
       {/* Header */}
-      <div className="notif-pref-header">
-        <Bell className="notif-pref-icon" size={24} />
+      <div className="flex items-center gap-3 px-6 py-5 border-b border-[#1E293B]">
+        <div className="p-1.5 rounded-lg bg-[rgba(59,130,246,0.1)] text-[#3B82F6] flex-shrink-0">
+          <Bell size={20} />
+        </div>
         <div>
-          <h2 id="notification-preferences-title">Notification Preferences</h2>
-          <p>Choose which events you want to be notified about, and through which channels.</p>
+          <h2
+            id="notification-preferences-title"
+            className="text-[#F1F5F9] font-semibold text-[1.05rem] m-0"
+          >
+            Notification Preferences
+          </h2>
+          <p className="text-slate-500 text-[0.8rem] m-0 mt-0.5">
+            Choose which events you want to be notified about, and through which channels.
+          </p>
         </div>
       </div>
 
-      {/* Phone verification */}
-      <div className="notif-phone-section">
-        <div className="notif-phone-header">
-          <span className="notif-phone-title">SMS Notifications</span>
+      {/* SMS verification */}
+      <div className="px-6 py-4 border-b border-[#1E293B] bg-[rgba(30,41,59,0.3)]">
+        <div className="flex items-center gap-2.5 mb-3">
+          <span className="text-[0.875rem] font-semibold text-[#E2E8F0]">SMS Notifications</span>
           {phoneVerified ? (
-            <span className="notif-phone-verified" aria-label="Phone verified">
-              <CheckCircle2 size={14} /> Verified
+            <span className="flex items-center gap-1 text-emerald-400 text-xs font-medium" aria-label="Phone verified">
+              <CheckCircle2 size={13} /> Verified
             </span>
           ) : (
-            <span className="notif-phone-unverified">Phone verification required to enable SMS</span>
+            <span className="text-amber-400 text-xs">Phone verification required to enable SMS</span>
           )}
         </div>
 
         {!phoneVerified && (
-          <div className="notif-phone-form">
-            <div className="notif-phone-row">
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2">
               <input
                 type="tel"
-                className="notif-phone-input"
+                className="flex-1 min-w-0 bg-[#0F1117] border border-[#334155] rounded-lg px-3 py-2 text-[#E2E8F0] text-sm outline-none transition-colors focus:border-[#3B82F6] disabled:opacity-60 disabled:cursor-not-allowed"
                 placeholder="+1 555 000 0000"
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
@@ -176,21 +332,22 @@ const NotificationPreferences: React.FC = () => {
                 disabled={otpSent}
               />
               <button
-                className="notif-phone-btn"
+                type="button"
+                className="flex items-center gap-1.5 px-4 py-2 bg-[#1E293B] border border-[#334155] rounded-lg text-[#CBD5E1] text-sm font-medium cursor-pointer whitespace-nowrap transition-colors hover:bg-[#293548] hover:border-[#475569] disabled:opacity-60 disabled:cursor-not-allowed"
                 onClick={handleSendOtp}
                 disabled={otpLoading || otpSent}
                 aria-label="Send OTP"
               >
-                {otpLoading ? <Loader2 className="notif-spinner" size={14} /> : null}
+                {otpLoading && <Loader2 className="animate-spin" size={13} />}
                 {otpSent ? 'OTP Sent' : 'Send OTP'}
               </button>
             </div>
 
             {otpSent && (
-              <div className="notif-phone-row">
+              <div className="flex gap-2">
                 <input
                   type="text"
-                  className="notif-phone-input"
+                  className="flex-1 min-w-0 bg-[#0F1117] border border-[#334155] rounded-lg px-3 py-2 text-[#E2E8F0] text-sm outline-none transition-colors focus:border-[#3B82F6]"
                   placeholder="Enter verification code"
                   value={otp}
                   onChange={(e) => setOtp(e.target.value)}
@@ -199,78 +356,186 @@ const NotificationPreferences: React.FC = () => {
                   maxLength={6}
                 />
                 <button
-                  className="notif-phone-btn notif-phone-btn--primary"
+                  type="button"
+                  className="flex items-center gap-1.5 px-4 py-2 bg-[rgba(59,130,246,0.15)] border border-[#3B82F6] rounded-lg text-[#60A5FA] text-sm font-medium cursor-pointer whitespace-nowrap transition-colors hover:bg-[rgba(59,130,246,0.25)] disabled:opacity-60 disabled:cursor-not-allowed"
                   onClick={handleVerifyOtp}
                   disabled={verifyLoading}
                   aria-label="Verify OTP"
                 >
-                  {verifyLoading ? <Loader2 className="notif-spinner" size={14} /> : null}
+                  {verifyLoading && <Loader2 className="animate-spin" size={13} />}
                   Verify
                 </button>
               </div>
             )}
 
             {phoneError && (
-              <p className="notif-phone-error" role="alert">
-                {phoneError}
-              </p>
+              <p className="text-[#F87171] text-xs mt-1" role="alert">{phoneError}</p>
             )}
           </div>
         )}
       </div>
 
-      {/* Channel header */}
-      <div className="notif-channel-header" aria-hidden="true">
-        <span className="notif-channel-label">Email</span>
-        <span className="notif-channel-label">SMS</span>
+      {/* Push notification opt-in */}
+      <div className="px-6 py-4 border-b border-[#1E293B] bg-[rgba(30,41,59,0.2)]">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-2.5">
+            <div className="p-1 rounded-md bg-[rgba(139,92,246,0.15)] text-purple-400">
+              <Smartphone size={16} />
+            </div>
+            <div>
+              <span className="text-[0.875rem] font-semibold text-[#E2E8F0]">Push Notifications</span>
+              <p className="text-slate-500 text-xs mt-0.5 m-0">
+                Receive instant alerts in your browser
+              </p>
+            </div>
+          </div>
+          {!pushEnabled ? (
+            <button
+              type="button"
+              onClick={handleRequestPush}
+              disabled={pushRequesting || !('Notification' in window)}
+              className="flex items-center gap-1.5 px-4 py-2 bg-[rgba(139,92,246,0.15)] border border-purple-500/40 rounded-lg text-purple-300 text-sm font-medium cursor-pointer whitespace-nowrap transition-colors hover:bg-[rgba(139,92,246,0.25)] disabled:opacity-60 disabled:cursor-not-allowed"
+              aria-label="Enable push notifications"
+            >
+              {pushRequesting && <Loader2 className="animate-spin" size={13} />}
+              Enable Push Notifications
+            </button>
+          ) : (
+            <span className="flex items-center gap-1 text-emerald-400 text-sm font-medium">
+              <CheckCircle2 size={14} /> Enabled
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Column headers */}
+      <div className="flex justify-end gap-0 px-6 pt-3 pb-0" aria-hidden="true">
+        {CHANNELS.map(({ key, label }) => (
+          <div key={key} className="w-[72px] text-center text-[0.65rem] font-semibold text-slate-600 uppercase tracking-wider">
+            {label}
+          </div>
+        ))}
+        {/* Extra space for the saved indicator */}
+        <div className="w-[72px]" />
       </div>
 
       {/* Categories */}
-      <div className="notif-pref-list">
-        {CATEGORIES.map((cat) => (
-          <div key={cat.label} className="notif-category">
-            <h3 className="notif-category-title">{cat.label}</h3>
-            {cat.events.map(({ event, label }) => (
-              <div key={event} className="notif-pref-row">
-                <span className="notif-pref-label">{label}</span>
+      <div className="px-6 pb-4">
+        {CATEGORIES.map((cat, catIndex) => (
+          <div
+            key={cat.label}
+            className={`py-4 ${catIndex > 0 ? 'border-t border-[rgba(30,41,59,0.6)]' : ''}`}
+          >
+            {/* Category header with bulk toggles */}
+            <div className="flex items-center justify-between mb-1">
+              <h3 className="text-[0.65rem] font-bold text-slate-600 uppercase tracking-widest m-0">
+                {cat.label}
+              </h3>
 
-                <div className="notif-pref-toggles">
+              {/* Bulk toggle buttons per channel */}
+              <div className="flex items-center gap-0">
+                {CHANNELS.map(({ key, label }) => {
+                  const fullyOn = isCategoryFullyEnabled(cat, key);
+                  const partial = isCategoryPartiallyEnabled(cat, key);
+                  const isDisabled = key === 'sms' && !phoneVerified;
+                  const isPushDisabled = key === 'push' && !pushEnabled;
+
+                  return (
+                    <div key={key} className="w-[72px] flex justify-center">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          !isDisabled &&
+                          !isPushDisabled &&
+                          handleCategoryBulkToggle(cat, key, !fullyOn)
+                        }
+                        disabled={isDisabled || isPushDisabled}
+                        title={
+                          isDisabled
+                            ? 'Verify your phone to enable SMS'
+                            : isPushDisabled
+                            ? 'Enable push notifications first'
+                            : fullyOn
+                            ? `Disable all ${label} for ${cat.label}`
+                            : `Enable all ${label} for ${cat.label}`
+                        }
+                        className={`text-[0.6rem] font-semibold px-1.5 py-0.5 rounded transition-colors cursor-pointer border ${
+                          isDisabled || isPushDisabled
+                            ? 'opacity-30 cursor-not-allowed border-transparent text-slate-600'
+                            : fullyOn
+                            ? 'bg-[rgba(59,130,246,0.15)] border-[#3B82F6]/40 text-[#60A5FA]'
+                            : partial
+                            ? 'bg-[rgba(251,191,36,0.1)] border-amber-500/30 text-amber-400'
+                            : 'bg-transparent border-slate-700/50 text-slate-600 hover:border-slate-500 hover:text-slate-400'
+                        }`}
+                        aria-label={`${fullyOn ? 'Disable' : 'Enable'} all ${label} notifications for ${cat.label}`}
+                        aria-pressed={fullyOn}
+                      >
+                        {fullyOn ? 'All on' : partial ? 'Partial' : 'All off'}
+                      </button>
+                    </div>
+                  );
+                })}
+                {/* Spacer to align with saved indicator column */}
+                <div className="w-[72px]" />
+              </div>
+            </div>
+
+            {/* Event rows */}
+            {cat.events.map(({ event, label }) => (
+              <div
+                key={event}
+                className="flex items-center justify-between py-3 border-b border-[rgba(30,41,59,0.4)] last:border-b-0 gap-4"
+              >
+                <span className="flex-1 text-sm font-medium text-[#E2E8F0]">{label}</span>
+
+                <div className="flex items-center gap-0 flex-shrink-0">
                   {/* Email toggle */}
-                  <label className="notif-switch" htmlFor={`${event}-email`}>
-                    <input
+                  <div className="w-[72px] flex justify-center">
+                    <ToggleSwitch
                       id={`${event}-email`}
-                      type="checkbox"
                       checked={prefs[event]?.email ?? false}
                       onChange={() => handleToggle(event, 'email')}
-                      aria-label={`${label} email notifications`}
+                      ariaLabel={`${label} email notifications`}
                     />
-                    <span className="notif-slider round" />
-                  </label>
+                  </div>
 
                   {/* SMS toggle */}
-                  <label
-                    className={`notif-switch ${!phoneVerified ? 'notif-switch--disabled' : ''}`}
-                    htmlFor={`${event}-sms`}
-                    title={!phoneVerified ? 'Verify your phone number to enable SMS' : undefined}
-                  >
-                    <input
+                  <div className="w-[72px] flex justify-center">
+                    <ToggleSwitch
                       id={`${event}-sms`}
-                      type="checkbox"
                       checked={prefs[event]?.sms ?? false}
                       onChange={() => handleToggle(event, 'sms')}
                       disabled={!phoneVerified}
-                      aria-label={`${label} SMS notifications`}
-                      aria-disabled={!phoneVerified}
+                      ariaLabel={`${label} SMS notifications`}
+                      title={!phoneVerified ? 'Verify your phone number to enable SMS' : undefined}
                     />
-                    <span className="notif-slider round" />
-                  </label>
+                  </div>
+
+                  {/* Push toggle */}
+                  <div className="w-[72px] flex justify-center">
+                    <ToggleSwitch
+                      id={`${event}-push`}
+                      checked={prefs[event]?.push ?? false}
+                      onChange={() => handleToggle(event, 'push')}
+                      disabled={!pushEnabled}
+                      ariaLabel={`${label} push notifications`}
+                      title={!pushEnabled ? 'Enable push notifications first' : undefined}
+                    />
+                  </div>
 
                   {/* Inline saved indicator */}
-                  {savedEvent === event && (
-                    <span className="notif-saved-indicator" role="status" aria-live="polite">
-                      <CheckCircle2 size={13} /> Saved
-                    </span>
-                  )}
+                  <div className="w-[72px] flex justify-center">
+                    {savedEvent === event ? (
+                      <span
+                        className="flex items-center gap-1 text-emerald-400 text-xs font-medium whitespace-nowrap animate-[fadeInUp_0.25s_ease-out]"
+                        role="status"
+                        aria-live="polite"
+                      >
+                        <CheckCircle2 size={12} /> Saved
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
               </div>
             ))}

--- a/frontend/src/pages/Shipments/Shipments.tsx
+++ b/frontend/src/pages/Shipments/Shipments.tsx
@@ -30,7 +30,9 @@ import ShipmentFilters, {
 } from "./ShipmentFilters";
 import "./Shipments.css";
 
-type ViewMode = "list" | "kanban";
+type ListMode = "table" | "grid";
+
+const LIST_MODE_KEY = "shipments-list-mode";
 
 function exportShipmentsToCSV(shipments: Shipment[], filename?: string): void {
   const headers = [
@@ -124,14 +126,22 @@ const Shipments: React.FC = () => {
   const [timeframeFilter, setTimeframeFilter] = useState<"ALL" | "30" | "90">(
     "ALL",
   );
-  const [viewMode] = useState<ViewMode>(() => {
+  const [listMode, setListMode] = useState<ListMode>(() => {
     try {
-      const saved = localStorage.getItem("navin_shipments_view");
-      return saved === "kanban" ? "kanban" : "list";
+      const saved = localStorage.getItem(LIST_MODE_KEY);
+      return saved === "grid" ? "grid" : "table";
     } catch {
-      return "list";
+      return "table";
     }
   });
+  const handleListModeChange = (mode: ListMode) => {
+    setListMode(mode);
+    try {
+      localStorage.setItem(LIST_MODE_KEY, mode);
+    } catch {
+      // ignore
+    }
+  };
   const [priorityFilter, setPriorityFilter] = useState<
     "ALL" | ShipmentPriority
   >("ALL");
@@ -411,6 +421,44 @@ const Shipments: React.FC = () => {
       <div className="shipments-header">
         <h1>Shipments</h1>
         <div className="flex items-center gap-3">
+          {/* List / Grid sub-toggle (only visible in list view) */}
+          {view === "list" && (
+            <div
+              className="inline-flex items-center rounded-lg border border-[rgba(98,255,255,0.15)] bg-[rgba(19,186,186,0.04)] p-0.5"
+              role="group"
+              aria-label="Toggle list or grid layout"
+            >
+              <button
+                type="button"
+                onClick={() => handleListModeChange("table")}
+                aria-pressed={listMode === "table"}
+                title="Table view"
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors cursor-pointer ${
+                  listMode === "table"
+                    ? "bg-[#62ffff] text-black"
+                    : "text-[#94a3b8] hover:text-white"
+                }`}
+              >
+                <List size={14} />
+                Table
+              </button>
+              <button
+                type="button"
+                onClick={() => handleListModeChange("grid")}
+                aria-pressed={listMode === "grid"}
+                title="Grid view"
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors cursor-pointer ${
+                  listMode === "grid"
+                    ? "bg-[#62ffff] text-black"
+                    : "text-[#94a3b8] hover:text-white"
+                }`}
+              >
+                <LayoutGrid size={14} />
+                Grid
+              </button>
+            </div>
+          )}
+
           {/* View toggle */}
           <div
             className="inline-flex items-center rounded-lg border border-[rgba(98,255,255,0.2)] bg-[rgba(19,186,186,0.05)] p-0.5"
@@ -640,8 +688,6 @@ const Shipments: React.FC = () => {
 
           {error ? (
             <div className="shipments-error">{error}</div>
-          ) : viewMode === "kanban" ? (
-            <ShipmentsKanban />
           ) : isEmpty ? (
             <EmptyState
               icon={<Package size={28} />}
@@ -685,7 +731,96 @@ const Shipments: React.FC = () => {
                 shipments
               </div>
 
-              {/* Sticky table header */}
+              {listMode === "grid" ? (
+                /* ── Grid card view ── */
+                <>
+                  <div
+                    className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mt-4"
+                    aria-label="Shipments grid"
+                  >
+                    {filteredShipments.map((shipment) => {
+                      const selected = isSelected(shipment.id);
+                      return (
+                        <div
+                          key={shipment.id}
+                          onClick={() =>
+                            navigate(`/dashboard/shipments/${shipment.id}`)
+                          }
+                          role="button"
+                          tabIndex={0}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ")
+                              navigate(`/dashboard/shipments/${shipment.id}`);
+                          }}
+                          aria-label={`View shipment ${shipment.id}`}
+                          className={`relative flex flex-col gap-3 p-4 rounded-xl border cursor-pointer transition-all duration-200 outline-none
+                            focus-visible:ring-2 focus-visible:ring-[#62ffff]/50
+                            ${
+                              selected
+                                ? "bg-[rgba(98,255,255,0.08)] border-[rgba(98,255,255,0.4)]"
+                                : "bg-[rgba(255,255,255,0.02)] border-[rgba(255,255,255,0.07)] hover:bg-[rgba(98,255,255,0.04)] hover:border-[rgba(98,255,255,0.25)]"
+                            }`}
+                        >
+                          {/* Select checkbox */}
+                          <input
+                            type="checkbox"
+                            aria-label={`Select shipment ${shipment.id}`}
+                            checked={selected}
+                            onChange={() => toggleOne(shipment.id)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="absolute top-3 right-3 cursor-pointer accent-[#62ffff] w-4 h-4"
+                          />
+
+                          {/* Shipment ID */}
+                          <div className="flex items-center gap-2 pr-6">
+                            <Package size={14} className="text-[#62ffff] flex-shrink-0" />
+                            <span className="text-[0.75rem] font-mono text-[#62ffff] truncate">
+                              {shipment.id}
+                            </span>
+                          </div>
+
+                          {/* Route */}
+                          <div className="flex flex-col gap-1">
+                            <div className="flex items-center gap-1.5 text-xs text-slate-400">
+                              <span className="font-medium text-slate-300 truncate">{shipment.origin}</span>
+                              <span className="text-slate-600">→</span>
+                              <span className="font-medium text-slate-300 truncate">{shipment.destination}</span>
+                            </div>
+                          </div>
+
+                          {/* Badges */}
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <StatusBadge status={shipment.status} />
+                            {shipment.priority && (
+                              <PriorityBadge priority={shipment.priority as ShipmentPriority} />
+                            )}
+                          </div>
+
+                          {/* Date */}
+                          <div className="text-[0.7rem] text-slate-600 mt-auto">
+                            {safeFormatDate(shipment.createdAt)}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {isLoading && (
+                    <div className="shipments-loading" aria-live="polite">
+                      Loading more shipments…
+                    </div>
+                  )}
+                  {!hasMore && filteredShipments.length > 0 && (
+                    <div className="shipments-summary" style={{ marginTop: "0.5rem" }}>
+                      {isAnyFilterActive
+                        ? `${filteredShipments.length} matching shipments`
+                        : `All ${total} shipments loaded`}
+                    </div>
+                  )}
+                </>
+              ) : (
+                /* ── Table view ── */
+                <>
               <table
                 className="shipments-table"
                 style={{ tableLayout: "fixed", width: "100%" }}
@@ -817,6 +952,8 @@ const Shipments: React.FC = () => {
                     ? `${filteredShipments.length} matching shipments`
                     : `All ${total} shipments loaded`}
                 </div>
+              )}
+                </>
               )}
             </>
           )}

--- a/frontend/src/pages/auth/Register/CompanyRegister.tsx
+++ b/frontend/src/pages/auth/Register/CompanyRegister.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Eye, EyeOff, ChevronLeft, Check, Pencil } from "lucide-react";
+import { Eye, EyeOff, ChevronLeft, Pencil } from "lucide-react";
 import { authApi } from "../../../services/api";
 import PasswordStrengthMeter from "../../../components/ui/PasswordStrengthMeter";
+import { ProgressStepper, type StepDef } from "../../../components/ui/ProgressStepper";
 
 const INDUSTRIES = [
   "Agriculture",
@@ -96,7 +97,12 @@ const selectBase =
 const labelClass = "text-[0.85rem] font-medium text-[rgba(255,255,255,0.6)] ml-1";
 const errorClass = "text-[#FF4D4D] text-[0.75rem] mt-1 ml-1";
 
-const STEP_LABELS = ["Company", "Admin", "Review"];
+const REGISTER_STEPS: StepDef[] = [
+  { label: 'Company', description: 'Tell us about your company' },
+  { label: 'Admin', description: 'Set up your admin credentials' },
+  { label: 'Review', description: 'Confirm your details' },
+];
+
 const STEP_TITLES = ["Company Info", "Admin Account", "Review & Submit"];
 const STEP_DESCRIPTIONS = [
   "Tell us about your company",
@@ -193,42 +199,6 @@ const CompanyRegister: React.FC = () => {
 
 
 
-  const renderStepIndicator = () => (
-    <div className="flex items-center justify-center mb-8" aria-label="Registration steps">
-      {[1, 2, 3].map((s, i) => (
-        <React.Fragment key={s}>
-          <div className="flex flex-col items-center gap-1.5">
-            <div
-              className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold transition-all ${
-                step === s
-                  ? "bg-[#00DAC1] text-black"
-                  : step > s
-                  ? "bg-[rgba(0,218,193,0.15)] border-2 border-[#00DAC1] text-[#00DAC1]"
-                  : "bg-[rgba(255,255,255,0.05)] border-2 border-[rgba(255,255,255,0.2)] text-[rgba(255,255,255,0.4)]"
-              }`}
-              aria-current={step === s ? "step" : undefined}
-            >
-              {step > s ? <Check size={16} /> : s}
-            </div>
-            <span
-              className={`text-[0.7rem] font-medium ${
-                step >= s ? "text-[#00DAC1]" : "text-[rgba(255,255,255,0.3)]"
-              }`}
-            >
-              {STEP_LABELS[i]}
-            </span>
-          </div>
-          {i < 2 && (
-            <div
-              className={`h-px flex-1 mx-2 mb-4 transition-all ${
-                step > s ? "bg-[#00DAC1]" : "bg-[rgba(255,255,255,0.1)]"
-              }`}
-            />
-          )}
-        </React.Fragment>
-      ))}
-    </div>
-  );
 
 
 
@@ -592,7 +562,7 @@ const CompanyRegister: React.FC = () => {
           </p>
         </div>
 
-        {renderStepIndicator()}
+        <ProgressStepper steps={REGISTER_STEPS} currentStep={step} className="mb-8" />
 
         {step === 1 && renderStep1()}
         {step === 2 && renderStep2()}


### PR DESCRIPTION
…(#545 #543 #542)

- #545: Add reusable ProgressStepper component (ui/ProgressStepper) with completed/active/upcoming states, connector lines, and optional step descriptions. Replace inline step indicator in CompanyRegister.tsx.

- #543: Rewrite NotificationPreferences with full Tailwind. Add per-channel toggles (email/sms/push), category-level bulk on/off, SMS phone verification flow, push notification permission opt-in, and inline saved indicator. Remove legacy NotificationPreferences.css import.

- #542: Add list/grid view toggle to Shipments page. Grid renders responsive card layout (1-4 columns). Persists choice to localStorage. Remove dead viewMode state.

Closes #545 
Closes #543 
Closes #542 