### PR TITLE
feat: auth refresh-on-focus, Help Center expansion, wire Payments/Set…

### DIFF
--- a/frontend/src/hooks/useAuth.test.ts
+++ b/frontend/src/hooks/useAuth.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useAuth } from './useAuth';
+
+const AUTH_STORAGE_KEY = 'authToken';
+
+function base64url(input: object): string {
+  const json = JSON.stringify(input);
+  const base64 = btoa(json);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = base64url({ alg: 'HS256', typ: 'JWT' });
+  const body = base64url(payload);
+  return `${header}.${body}.signature`;
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  });
+}
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setVisibility('visible');
+  });
+
+  afterEach(() => {
+    setVisibility('visible');
+  });
+
+  it('mounts with a valid token and becomes authenticated', async () => {
+    const token = makeToken({ sub: 'user-1', role: 'company', exp: Math.floor(Date.now() / 1000) + 3600 });
+    localStorage.setItem(AUTH_STORAGE_KEY, token);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.role).toBe('company');
+    expect(result.current.userId).toBe('user-1');
+    expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBe(token);
+  });
+
+  it('mounts with an expired token and clears it', async () => {
+    const token = makeToken({ sub: 'user-1', role: 'company', exp: Math.floor(Date.now() / 1000) - 3600 });
+    localStorage.setItem(AUTH_STORAGE_KEY, token);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
+  });
+
+  it('keeps state unchanged when the tab regains focus with a still-valid token', async () => {
+    const token = makeToken({ sub: 'user-1', role: 'company', exp: Math.floor(Date.now() / 1000) + 3600 });
+    localStorage.setItem(AUTH_STORAGE_KEY, token);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(true);
+
+    setVisibility('visible');
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBe(token);
+  });
+
+  it('transitions to unauthenticated when the tab regains focus with an expired token', async () => {
+    const token = makeToken({ sub: 'user-1', role: 'company', exp: Math.floor(Date.now() / 1000) + 3600 });
+    localStorage.setItem(AUTH_STORAGE_KEY, token);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(true);
+
+    const expiredToken = makeToken({ sub: 'user-1', role: 'company', exp: Math.floor(Date.now() / 1000) - 3600 });
+    localStorage.setItem(AUTH_STORAGE_KEY, expiredToken);
+
+    setVisibility('visible');
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -31,7 +31,7 @@ export function useAuth(): AuthState {
   const [userId, setUserId] = useState<string | null>(null);
 
   useEffect(() => {
-    const timer = window.setTimeout(() => {
+    function checkToken() {
       const token = localStorage.getItem(AUTH_STORAGE_KEY);
 
       if (!token) {
@@ -52,10 +52,21 @@ export function useAuth(): AuthState {
       }
 
       setIsLoading(false);
-    }, AUTH_CHECK_DELAY_MS);
+    }
+
+    const timer = window.setTimeout(checkToken, AUTH_CHECK_DELAY_MS);
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        checkToken();
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);
 

--- a/frontend/src/pages/HelpCenter/HelpCenter.tsx
+++ b/frontend/src/pages/HelpCenter/HelpCenter.tsx
@@ -15,7 +15,12 @@ import {
   BarChart3,
   FileText,
   ChevronRight,
+  ChevronDown,
   ListChecks,
+  Link2,
+  Landmark,
+  PlayCircle,
+  Keyboard,
 } from 'lucide-react';
 
 // === Types
@@ -27,6 +32,24 @@ interface HelpTask {
   path: string;
   icon: React.ReactNode;
   keywords: string[];
+}
+
+interface FaqEntry {
+  question: string;
+  answer: string;
+}
+
+interface QuickLink {
+  id: string;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+}
+
+interface ShortcutRow {
+  keys: string;
+  action: string;
 }
 
 // === Data
@@ -82,12 +105,52 @@ const COMMON_TASKS: HelpTask[] = [
   },
 ];
 
+const FAQ_ENTRIES: FaqEntry[] = [
+  {
+    question: 'How do I create a new shipment?',
+    answer:
+      'Go to Shipments and select "New Shipment". Fill in the pickup and delivery details, attach any documents or photos, and submit — the shipment is registered on-chain and appears in your Shipments list with a Pending status.',
+  },
+  {
+    question: 'How does escrow and automated settlement work?',
+    answer:
+      'When a shipment is confirmed, payment funds are held in escrow on the Stellar blockchain. Once the delivery milestones are verified, the smart contract automatically releases the funds to the logistics provider — no manual invoicing or approval step required.',
+  },
+  {
+    question: 'How do I connect my Stellar wallet?',
+    answer:
+      'Open Settings and choose "Connect Wallet". Select your wallet provider (Freighter, Lobstr, or Solar Wallet) and approve the connection request. Once connected, your wallet address is used to sign and verify settlement transactions.',
+  },
+  {
+    question: 'What does each shipment status mean?',
+    answer:
+      'Pending means the shipment is registered but not yet picked up. In Transit means it is actively moving between milestones. Delivered means all milestones are complete. Exception flags an anomaly (delay, damage, or missed checkpoint) that needs attention.',
+  },
+  {
+    question: 'How do I invite a team member?',
+    answer:
+      'Go to Team, select "Invite", and enter the teammate\'s email along with their role. They will receive an invite link to set up their account with the permissions you assigned.',
+  },
+];
+
+const SHORTCUT_ROWS: ShortcutRow[] = [
+  { keys: 'Alt + D', action: 'Go to Dashboard' },
+  { keys: 'Alt + Shift + S', action: 'Go to Shipments' },
+  { keys: 'Alt + E', action: 'Go to Settlements' },
+  { keys: 'Alt + P', action: 'Go to Payments' },
+  { keys: 'Alt + L', action: 'Go to Analytics' },
+  { keys: 'Alt + Shift + N', action: 'Go to Notifications' },
+  { keys: 'Alt + Shift + Q', action: 'Go to Settings' },
+  { keys: '? / Shift + /', action: 'Toggle this help dialog' },
+];
+
 // === Component
 
 const HelpCenter: React.FC = () => {
   const navigate = useNavigate();
   const { addToast } = useToast();
   const [query, setQuery] = useState<string>('');
+  const [openFaqIndex, setOpenFaqIndex] = useState<number | null>(null);
 
   const filteredTasks = useMemo<HelpTask[]>(() => {
     const term = query.trim().toLowerCase();
@@ -110,6 +173,37 @@ const HelpCenter: React.FC = () => {
     resetChecklist();
     addToast('Setup checklist restored on your dashboard.', 'success');
   };
+
+  const quickLinks: QuickLink[] = [
+    {
+      id: 'blockchain-ledger',
+      label: 'Blockchain Ledger',
+      description: 'View on-chain shipment and settlement records.',
+      icon: <Link2 size={18} />,
+      onClick: () => navigate('/dashboard/blockchain-ledger'),
+    },
+    {
+      id: 'settlements',
+      label: 'Settlements',
+      description: 'Track escrow and payment settlement status.',
+      icon: <Landmark size={18} />,
+      onClick: () => navigate('/dashboard/settlements'),
+    },
+    {
+      id: 'analytics',
+      label: 'Analytics',
+      description: 'Review revenue, cost, and performance trends.',
+      icon: <BarChart3 size={18} />,
+      onClick: () => navigate('/dashboard/analytics'),
+    },
+    {
+      id: 'restart-tour',
+      label: 'Restart onboarding tour',
+      description: 'Replay the guided introduction to Navin.',
+      icon: <RotateCcw size={18} />,
+      onClick: handleRestartTour,
+    },
+  ];
 
   return (
     <div className="w-full max-w-3xl mx-auto px-6 py-8 max-md:px-4">
@@ -200,6 +294,116 @@ const HelpCenter: React.FC = () => {
             <ListChecks size={16} />
             Restore Setup Checklist
           </button>
+        </div>
+      </section>
+
+      <section aria-labelledby="quick-links-heading" className="mb-6">
+        <h2
+          id="quick-links-heading"
+          className="text-[13px] font-semibold uppercase tracking-[0.05em] text-[#64748b] mb-3"
+        >
+          Quick links
+        </h2>
+        <ul className="list-none m-0 p-0 grid grid-cols-3 gap-3 max-md:grid-cols-1">
+          {quickLinks.map((link) => (
+            <li key={link.id}>
+              <button
+                type="button"
+                onClick={link.onClick}
+                className="w-full h-full flex flex-col items-start gap-2 text-left rounded-xl border border-[#1e293b] bg-[#14171e] p-4 cursor-pointer transition-colors hover:border-[#62ffff] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#62ffff]"
+              >
+                <span className="text-[#62ffff]">{link.icon}</span>
+                <span className="text-sm font-semibold text-white">{link.label}</span>
+                <span className="text-xs text-[#94a3b8] leading-relaxed">{link.description}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="faq-heading" className="mb-6">
+        <h2
+          id="faq-heading"
+          className="text-[13px] font-semibold uppercase tracking-[0.05em] text-[#64748b] mb-3"
+        >
+          Frequently asked questions
+        </h2>
+        <div className="flex flex-col gap-2">
+          {FAQ_ENTRIES.map((entry, index) => {
+            const isOpen = openFaqIndex === index;
+            return (
+              <div
+                key={entry.question}
+                className="rounded-xl border border-[#1e293b] bg-[#14171e] overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => setOpenFaqIndex(isOpen ? null : index)}
+                  aria-expanded={isOpen}
+                  className="w-full flex items-center justify-between gap-4 px-4 py-3.5 text-left cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#62ffff]"
+                >
+                  <span className="text-sm font-semibold text-white">{entry.question}</span>
+                  <ChevronDown
+                    size={16}
+                    className={`shrink-0 text-[#64748b] transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                  />
+                </button>
+                {isOpen && (
+                  <p className="px-4 pb-4 text-sm text-[#94a3b8] leading-relaxed">{entry.answer}</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section aria-labelledby="shortcuts-heading" className="bg-[#14171e] border border-[#1e293b] rounded-xl p-6 mb-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Keyboard size={18} className="text-[#62ffff]" />
+          <h2 id="shortcuts-heading" className="text-lg font-semibold text-white m-0">
+            Keyboard shortcuts
+          </h2>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-[#1e293b]">
+                <th className="text-left font-semibold text-[#64748b] py-2 pr-4 whitespace-nowrap">
+                  Shortcut key
+                </th>
+                <th className="text-left font-semibold text-[#64748b] py-2">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {SHORTCUT_ROWS.map((row) => (
+                <tr key={row.keys} className="border-b border-[#1e293b] last:border-b-0">
+                  <td className="py-2.5 pr-4 whitespace-nowrap">
+                    <kbd className="text-xs font-mono bg-[rgba(255,255,255,0.08)] border border-[rgba(255,255,255,0.15)] rounded px-2 py-1 text-[#62ffff]">
+                      {row.keys}
+                    </kbd>
+                  </td>
+                  <td className="py-2.5 text-[#cbd5e1]">{row.action}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section aria-labelledby="video-heading" className="mb-6">
+        <h2
+          id="video-heading"
+          className="text-[13px] font-semibold uppercase tracking-[0.05em] text-[#64748b] mb-3"
+        >
+          Video guide
+        </h2>
+        <div
+          data-src="https://www.youtube.com/watch?v=REPLACE_ME"
+          className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-[#1e293b] bg-[#14171e] p-10 text-center"
+        >
+          <PlayCircle size={40} className="text-[#62ffff]" />
+          <p className="text-sm font-semibold text-white m-0">Getting Started with Navin</p>
+          <p className="text-xs text-[#94a3b8] m-0">Video walkthrough coming soon.</p>
         </div>
       </section>
 

--- a/frontend/src/pages/Payments/PaymentHistory/PaymentHistory.tsx
+++ b/frontend/src/pages/Payments/PaymentHistory/PaymentHistory.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   ChevronDown,
@@ -6,44 +6,69 @@ import {
   ChevronRight,
   ExternalLink,
   ArrowUpDown,
+  AlertTriangle,
   X,
 } from "lucide-react";
 import PaymentSummaryCards from "../PaymentSummaryCards";
+import EmptyState from "@components/ui/EmptyState/EmptyState";
+import TableRowSkeleton from "@components/ui/Skeleton/TableRowSkeleton";
+import { useFocusTrap } from "@hooks/useFocusTrap";
+import {
+  settlementsApi,
+  Settlement,
+  SettlementStatus,
+  SettlementDetail,
+} from "@services/api/endpoints/settlements";
 
-type PaymentStatus = "Pending" | "Escrowed" | "Released" | "Failed";
-
-interface Payment {
-  id: string;
-  date: string;
-  shipmentId: string;
-  amount: number;
-  token: string;
-  status: PaymentStatus;
-  txHash: string;
-}
-
-const statusClasses: Record<PaymentStatus, string> = {
-  Pending:
+const statusClasses: Record<SettlementStatus, string> = {
+  PENDING:
     "bg-[rgba(245,158,11,0.15)] text-[#fbbf24] border border-[rgba(245,158,11,0.3)]",
-  Escrowed:
+  ESCROWED:
     "bg-[rgba(98,255,255,0.15)] text-[#62ffff] border border-[rgba(98,255,255,0.3)]",
-  Released:
+  RELEASED:
     "bg-[rgba(16,185,129,0.15)] text-[#34d399] border border-[rgba(16,185,129,0.3)]",
-  Failed:
+  DISPUTED:
     "bg-[rgba(239,68,68,0.15)] text-[#f87171] border border-[rgba(239,68,68,0.3)]",
+  FAILED:
+    "bg-[rgba(239,68,68,0.15)] text-[#f87171] border border-[rgba(239,68,68,0.3)]",
+};
+
+const statusDotClasses: Record<SettlementStatus, string> = {
+  PENDING: "bg-[#fbbf24]",
+  ESCROWED: "bg-[#62ffff]",
+  RELEASED: "bg-[#34d399]",
+  DISPUTED: "bg-[#f87171]",
+  FAILED: "bg-[#f87171]",
+};
+
+const truncateHash = (hash?: string) => {
+  if (!hash) return "-";
+  return `${hash.slice(0, 6)}...${hash.slice(-4)}`;
+};
+
+const getStellarExplorerUrl = (hash?: string) => {
+  if (!hash) return undefined;
+  return `https://stellar.expert/explorer/public/tx/${hash}`;
 };
 
 interface PaymentDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
-  payment: Payment | null;
+  settlement: Settlement | null;
+  detail: SettlementDetail | null;
+  isLoading?: boolean;
 }
 
 const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
   isOpen,
   onClose,
-  payment,
+  settlement,
+  detail,
+  isLoading,
 }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, isOpen, onClose);
+
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -52,13 +77,18 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
     return () => window.removeEventListener("keydown", handleEsc);
   }, [onClose]);
 
-  if (!isOpen || !payment) return null;
+  if (!isOpen) return null;
+
+  const effective = detail?.settlement ?? settlement;
+  if (!effective) return null;
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="payment-detail-title"
@@ -75,40 +105,52 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
             <X size={20} />
           </button>
         </div>
-        <dl className="flex flex-col gap-3 text-sm">
-          {(
-            [
-              ["Shipment ID", payment.shipmentId],
-              ["Date", new Date(payment.date).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })],
+        {isLoading ? (
+          <div className="flex flex-col gap-3">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="h-5 rounded bg-[rgba(98,255,255,0.1)] animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          <dl className="flex flex-col gap-3 text-sm">
+            {(
               [
-                "Amount",
-                `$${payment.amount.toLocaleString()} ${payment.token}`,
-              ],
-              ["Status", payment.status],
-            ] as [string, string][]
-          ).map(([label, value]) => (
-            <div key={label} className="flex justify-between gap-4">
-              <dt className="text-text-secondary">{label}</dt>
-              <dd className="text-white font-medium break-all text-right">
-                {value}
+                ["Shipment ID", effective.shipmentId],
+                ["Date", new Date(effective.createdAt).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })],
+                [
+                  "Amount",
+                  `${effective.amount.toLocaleString()} ${effective.token}`,
+                ],
+                ["Status", effective.status],
+              ] as [string, string][]
+            ).map(([label, value]) => (
+              <div key={label} className="flex justify-between gap-4">
+                <dt className="text-text-secondary">{label}</dt>
+                <dd className="text-white font-medium break-all text-right">
+                  {value}
+                </dd>
+              </div>
+            ))}
+            <div className="flex justify-between gap-4">
+              <dt className="text-text-secondary">Tx Hash</dt>
+              <dd className="text-right">
+                {effective.stellarTxHash ? (
+                  <a
+                    href={getStellarExplorerUrl(effective.stellarTxHash)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-xs text-[#62ffff] inline-flex items-center gap-1 hover:underline"
+                  >
+                    {truncateHash(effective.stellarTxHash)}
+                    <ExternalLink size={11} aria-hidden="true" />
+                  </a>
+                ) : (
+                  <span className="text-text-secondary text-xs">-</span>
+                )}
               </dd>
             </div>
-          ))}
-          <div className="flex justify-between gap-4">
-            <dt className="text-text-secondary">Tx Hash</dt>
-            <dd className="text-right">
-              <a
-                href={getStellarExplorerUrl(payment.txHash)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-xs text-[#62ffff] inline-flex items-center gap-1 hover:underline"
-              >
-                {truncateHash(payment.txHash)}
-                <ExternalLink size={11} aria-hidden="true" />
-              </a>
-            </dd>
-          </div>
-        </dl>
+          </dl>
+        )}
         <div className="mt-5 flex gap-3">
           <button
             onClick={onClose}
@@ -116,14 +158,16 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
           >
             Close
           </button>
-          <a
-            href={getStellarExplorerUrl(payment.txHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex-1 px-3 py-2 rounded-lg bg-[#00d4c8] text-black text-center text-sm font-semibold hover:bg-[#13baba] transition-colors"
-          >
-            Verify on Chain
-          </a>
+          {effective.stellarTxHash && (
+            <a
+              href={getStellarExplorerUrl(effective.stellarTxHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-1 px-3 py-2 rounded-lg bg-[#00d4c8] text-black text-center text-sm font-semibold hover:bg-[#13baba] transition-colors"
+            >
+              Verify on Chain
+            </a>
+          )}
         </div>
       </div>
     </div>
@@ -132,186 +176,66 @@ const PaymentDetailModal: React.FC<PaymentDetailModalProps> = ({
 
 const PaymentHistory: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 2500);
-    return () => clearTimeout(timer);
-  }, []);
-
-  const [filterStatus, setFilterStatus] = useState<PaymentStatus | "All">(
+  const [filterStatus, setFilterStatus] = useState<SettlementStatus | "All">(
     "All",
   );
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [currentPage, setCurrentPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedPayment, setSelectedPayment] = useState<Payment | null>(null);
+  const [selectedPayment, setSelectedPayment] = useState<Settlement | null>(null);
+  const [selectedDetail, setSelectedDetail] = useState<SettlementDetail | null>(null);
+  const [isModalLoading, setIsModalLoading] = useState(false);
   const itemsPerPage = 10;
 
-  const allPayments: Payment[] = [
-    {
-      id: "1",
-      date: "2026-02-26",
-      shipmentId: "SHP-9021",
-      amount: 5420.5,
-      token: "USDC",
-      status: "Released",
-      txHash: "0x4a9b2f81c3e5d7a9b2f81c3e5d7a9b2f81c3e5d7",
-    },
-    {
-      id: "2",
-      date: "2026-02-25",
-      shipmentId: "SHP-8842",
-      amount: 3200.0,
-      token: "XLM",
-      status: "Escrowed",
-      txHash: "0x9c1a9e55b7d4f2c8a1e9b7d4f2c8a1e9b7d4f2c8",
-    },
-    {
-      id: "3",
-      date: "2026-02-24",
-      shipmentId: "SHP-8711",
-      amount: 7850.75,
-      token: "USDC",
-      status: "Released",
-      txHash: "0x2e8f3a6c9d1b5e7f3a6c9d1b5e7f3a6c9d1b5e7f",
-    },
-    {
-      id: "4",
-      date: "2026-02-23",
-      shipmentId: "SHP-8590",
-      amount: 1250.0,
-      token: "USDC",
-      status: "Pending",
-      txHash: "0x7b4d2f9a8c3e6d1b4f9a8c3e6d1b4f9a8c3e6d1b",
-    },
-    {
-      id: "5",
-      date: "2026-02-22",
-      shipmentId: "SHP-8421",
-      amount: 4100.25,
-      token: "XLM",
-      status: "Released",
-      txHash: "0x5c9e1a7f3b8d2c6e1a7f3b8d2c6e1a7f3b8d2c6e",
-    },
-    {
-      id: "6",
-      date: "2026-02-21",
-      shipmentId: "SHP-8305",
-      amount: 2980.0,
-      token: "USDC",
-      status: "Failed",
-      txHash: "0x8d3f6b2a9c5e1d7f6b2a9c5e1d7f6b2a9c5e1d7f",
-    },
-    {
-      id: "7",
-      date: "2026-02-20",
-      shipmentId: "SHP-8192",
-      amount: 6750.5,
-      token: "USDC",
-      status: "Released",
-      txHash: "0x1f7c4e9b3a6d8f2c4e9b3a6d8f2c4e9b3a6d8f2c",
-    },
-    {
-      id: "8",
-      date: "2026-02-19",
-      shipmentId: "SHP-8043",
-      amount: 3450.0,
-      token: "XLM",
-      status: "Escrowed",
-      txHash: "0x6a2d8f1c5b9e3a7d8f1c5b9e3a7d8f1c5b9e3a7d",
-    },
-    {
-      id: "9",
-      date: "2026-02-18",
-      shipmentId: "SHP-7921",
-      amount: 5200.75,
-      token: "USDC",
-      status: "Released",
-      txHash: "0x9e5b3f7a2d6c1e8b3f7a2d6c1e8b3f7a2d6c1e8b",
-    },
-    {
-      id: "10",
-      date: "2026-02-17",
-      shipmentId: "SHP-7805",
-      amount: 2100.0,
-      token: "USDC",
-      status: "Pending",
-      txHash: "0x3c8a6f2d9b1e5c7a6f2d9b1e5c7a6f2d9b1e5c7a",
-    },
-    {
-      id: "11",
-      date: "2026-02-16",
-      shipmentId: "SHP-7692",
-      amount: 8900.5,
-      token: "XLM",
-      status: "Released",
-      txHash: "0x7d1f9c4a8e2b6d3f9c4a8e2b6d3f9c4a8e2b6d3f",
-    },
-    {
-      id: "12",
-      date: "2026-02-15",
-      shipmentId: "SHP-7543",
-      amount: 4320.25,
-      token: "USDC",
-      status: "Escrowed",
-      txHash: "0x2b6e9a3f7c1d5e8a3f7c1d5e8a3f7c1d5e8a3f7c",
-    },
-    {
-      id: "13",
-      date: "2026-02-14",
-      shipmentId: "SHP-7421",
-      amount: 1850.0,
-      token: "USDC",
-      status: "Released",
-      txHash: "0x5f3c8d1a9b7e2f4c8d1a9b7e2f4c8d1a9b7e2f4c",
-    },
-    {
-      id: "14",
-      date: "2026-02-13",
-      shipmentId: "SHP-7305",
-      amount: 6100.75,
-      token: "XLM",
-      status: "Failed",
-      txHash: "0x8a4f2c9d6b3e1a7f2c9d6b3e1a7f2c9d6b3e1a7f",
-    },
-    {
-      id: "15",
-      date: "2026-02-12",
-      shipmentId: "SHP-7192",
-      amount: 3700.0,
-      token: "USDC",
-      status: "Released",
-      txHash: "0x1d7b5f9c3a8e6d2b5f9c3a8e6d2b5f9c3a8e6d2b",
-    },
-    {
-      id: "16",
-      date: "2026-02-11",
-      shipmentId: "SHP-7081",
-      amount: 5550.5,
-      token: "USDC",
-      status: "Pending",
-      txHash: "0x4e9a2f6c8d1b7e3a2f6c8d1b7e3a2f6c8d1b7e3a",
-    },
-  ];
+  const [payments, setPayments] = useState<Settlement[]>([]);
+  const [total, setTotal] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(total / itemsPerPage));
 
-  const filteredPayments =
-    filterStatus === "All"
-      ? allPayments
-      : allPayments.filter((p) => p.status === filterStatus);
-  const sortedPayments = [...filteredPayments].sort((a, b) => {
-    const diff = new Date(a.date).getTime() - new Date(b.date).getTime();
-    return sortOrder === "desc" ? -diff : diff;
-  });
-  const totalPages = Math.ceil(sortedPayments.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const paginatedPayments = sortedPayments.slice(
-    startIndex,
-    startIndex + itemsPerPage,
-  );
-  const truncateHash = (hash: string) =>
-    `${hash.slice(0, 6)}...${hash.slice(-4)}`;
-  const getStellarExplorerUrl = (hash: string) =>
-    `https://stellar.expert/explorer/public/tx/${hash}`;
+  const load = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await settlementsApi.getSettlements({
+        page: currentPage,
+        limit: itemsPerPage,
+        status: filterStatus === "All" ? undefined : filterStatus,
+        sortBy: "createdAt",
+        sortOrder,
+      });
+      setPayments(res.data);
+      setTotal(res.total);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load payment history");
+      setPayments([]);
+      setTotal(0);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    Promise.resolve().then(() => {
+      void load();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPage, filterStatus, sortOrder]);
+
+  const openPaymentDetail = async (payment: Settlement) => {
+    setSelectedPayment(payment);
+    setSelectedDetail(null);
+    setIsModalOpen(true);
+    setIsModalLoading(true);
+    try {
+      const detail = await settlementsApi.getSettlementById(payment._id);
+      setSelectedDetail(detail);
+    } catch {
+      // Keep modal open with the list-row data already shown
+    } finally {
+      setIsModalLoading(false);
+    }
+  };
 
   const tableContainerClass =
     "bg-[rgba(19,186,186,0.05)] border border-[rgba(98,255,255,0.2)] rounded-2xl overflow-hidden mb-5 shadow-[inset_0_0_20px_0px_rgba(0,128,128,0.3)]";
@@ -319,8 +243,7 @@ const PaymentHistory: React.FC = () => {
     "text-left px-6 py-4 text-[11px] font-semibold text-[#62ffff] uppercase border-b border-[rgba(98,255,255,0.2)]";
   const tdClass = "px-6 py-4 text-sm border-b border-[rgba(98,255,255,0.2)]";
 
-
-  if (sortedPayments.length === 0) {
+  if (error) {
     return (
       <div className="p-6 md:p-4">
         <div className="mb-6">
@@ -329,14 +252,33 @@ const PaymentHistory: React.FC = () => {
             Track all payment transactions on the blockchain
           </p>
         </div>
-        <div className={`${tableContainerClass} px-10 py-20 text-center`}>
-          <div className="text-[64px] mb-4">💳</div>
-          <h2 className="text-xl font-bold mb-2 text-[#62ffff]">
-            No Payments Found
-          </h2>
+        <EmptyState
+          icon={<AlertTriangle size={28} />}
+          title="Failed to load payment history"
+          description={error}
+          action={{
+            label: "Retry",
+            onClick: () => {
+              setCurrentPage(1);
+              void load();
+            },
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (!isLoading && payments.length === 0) {
+    return (
+      <div className="p-6 md:p-4">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold mb-1">Payment History</h1>
           <p className="text-text-secondary text-sm">
-            There are no payment transactions matching your criteria.
+            Track all payment transactions on the blockchain
           </p>
+        </div>
+        <div className={tableContainerClass}>
+          <EmptyState.NoPayments />
         </div>
       </div>
     );
@@ -359,17 +301,18 @@ const PaymentHistory: React.FC = () => {
             <select
               value={filterStatus}
               onChange={(e) => {
-                setFilterStatus(e.target.value as PaymentStatus | "All");
+                setFilterStatus(e.target.value as SettlementStatus | "All");
                 setCurrentPage(1);
               }}
               aria-label="Filter by payment status"
               className="appearance-none bg-[rgba(19,186,186,0.1)] border border-[rgba(98,255,255,0.2)] text-text-primary px-3.5 py-2 pr-9 rounded-lg text-sm font-medium cursor-pointer outline-none hover:border-[#62ffff] hover:bg-[rgba(19,186,186,0.15)] transition-colors max-md:w-full"
             >
               <option value="All">All Status</option>
-              <option value="Pending">Pending</option>
-              <option value="Escrowed">Escrowed</option>
-              <option value="Released">Released</option>
-              <option value="Failed">Failed</option>
+              <option value="PENDING">Pending</option>
+              <option value="ESCROWED">Escrowed</option>
+              <option value="RELEASED">Released</option>
+              <option value="DISPUTED">Disputed</option>
+              <option value="FAILED">Failed</option>
             </select>
             <ChevronDown
               size={16}
@@ -420,72 +363,67 @@ const PaymentHistory: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {isLoading
-              ? [...Array(itemsPerPage)].map((_, i) => (
-                  <tr key={i}>
-                    {[...Array(5)].map((__, j) => (
-                      <td key={j} className={tdClass}>
-                        <div className="h-8 w-full rounded bg-[rgba(98,255,255,0.1)] animate-pulse" />
-                      </td>
-                    ))}
-                  </tr>
-                ))
-              : paginatedPayments.map((payment) => (
-                  <tr
-                    key={payment.id}
-                    className="hover:bg-[rgba(98,255,255,0.05)] transition-colors last:border-b-0 cursor-pointer"
-                    onClick={() => {
-                      setSelectedPayment(payment);
-                      setIsModalOpen(true);
-                    }}
-                  >
-                    <td className={`${tdClass} font-medium text-text-secondary`}>
-                      {new Date(payment.date).toLocaleDateString(undefined, {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      })}
-                    </td>
-                    <td className={tdClass}>
-                      <Link
-                        to={`/dashboard/shipments/${payment.shipmentId}`}
-                        className="text-[#62ffff] font-semibold no-underline hover:underline"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {payment.shipmentId}
-                      </Link>
-                    </td>
-                    <td className={tdClass}>
-                      <div className="flex flex-col gap-0.5">
-                        <span className="font-semibold text-sm">
-                          ${payment.amount.toLocaleString()}
-                        </span>
-                        <span className="text-[11px] text-text-secondary uppercase">
-                          {payment.token}
-                        </span>
-                      </div>
-                    </td>
-                    <td className={tdClass}>
-                      <span
-                        className={`px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase inline-block ${statusClasses[payment.status]}`}
-                      >
-                        {payment.status}
+            {isLoading ? (
+              <TableRowSkeleton count={itemsPerPage} />
+            ) : (
+              payments.map((payment) => (
+                <tr
+                  key={payment._id}
+                  className="hover:bg-[rgba(98,255,255,0.05)] transition-colors last:border-b-0 cursor-pointer"
+                  onClick={() => void openPaymentDetail(payment)}
+                >
+                  <td className={`${tdClass} font-medium text-text-secondary`}>
+                    {new Date(payment.createdAt).toLocaleDateString(undefined, {
+                      year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </td>
+                  <td className={tdClass}>
+                    <Link
+                      to={`/dashboard/shipments/${payment.shipmentId}`}
+                      className="text-[#62ffff] font-semibold no-underline hover:underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {payment.shipmentId}
+                    </Link>
+                  </td>
+                  <td className={tdClass}>
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-semibold text-sm">
+                        {payment.amount.toLocaleString()}
                       </span>
-                    </td>
-                    <td className={`${tdClass} font-mono text-xs`}>
+                      <span className="text-[11px] text-text-secondary uppercase">
+                        {payment.token}
+                      </span>
+                    </div>
+                  </td>
+                  <td className={tdClass}>
+                    <span
+                      className={`px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase inline-block ${statusClasses[payment.status]}`}
+                    >
+                      {payment.status}
+                    </span>
+                  </td>
+                  <td className={`${tdClass} font-mono text-xs`}>
+                    {payment.stellarTxHash ? (
                       <a
-                        href={getStellarExplorerUrl(payment.txHash)}
+                        href={getStellarExplorerUrl(payment.stellarTxHash)}
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={(e) => e.stopPropagation()}
                         className="text-text-secondary no-underline inline-flex items-center gap-1.5 transition-colors hover:text-[#62ffff]"
                       >
-                        {truncateHash(payment.txHash)}
+                        {truncateHash(payment.stellarTxHash)}
                         <ExternalLink size={12} className="text-[#62ffff]" aria-hidden="true" />
                       </a>
-                    </td>
-                  </tr>
-                ))}
+                    ) : (
+                      <span className="text-text-secondary">-</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>
@@ -499,14 +437,11 @@ const PaymentHistory: React.FC = () => {
                 className="h-28 rounded-2xl bg-[rgba(98,255,255,0.05)] border border-[rgba(98,255,255,0.2)] animate-pulse"
               />
             ))
-          : paginatedPayments.map((payment) => (
+          : payments.map((payment) => (
               <button
-                key={payment.id}
+                key={payment._id}
                 type="button"
-                onClick={() => {
-                  setSelectedPayment(payment);
-                  setIsModalOpen(true);
-                }}
+                onClick={() => void openPaymentDetail(payment)}
                 className="w-full text-left bg-[rgba(19,186,186,0.05)] border border-[rgba(98,255,255,0.2)] rounded-2xl p-4 shadow-[inset_0_0_15px_0px_rgba(0,128,128,0.2)] transition-all active:bg-[rgba(19,186,186,0.1)] focus-visible:outline-2 focus-visible:outline-[#62ffff]"
               >
                 {/* Top row: status badge + date */}
@@ -515,21 +450,13 @@ const PaymentHistory: React.FC = () => {
                     className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase ${statusClasses[payment.status]}`}
                   >
                     <span
-                      className={`inline-block w-1.5 h-1.5 rounded-full ${
-                        payment.status === "Released"
-                          ? "bg-[#34d399]"
-                          : payment.status === "Escrowed"
-                            ? "bg-[#62ffff]"
-                            : payment.status === "Pending"
-                              ? "bg-[#fbbf24]"
-                              : "bg-[#f87171]"
-                      }`}
+                      className={`inline-block w-1.5 h-1.5 rounded-full ${statusDotClasses[payment.status]}`}
                       aria-hidden="true"
                     />
                     {payment.status}
                   </span>
                   <span className="text-xs text-text-secondary">
-                    {new Date(payment.date).toLocaleDateString(undefined, {
+                    {new Date(payment.createdAt).toLocaleDateString(undefined, {
                       year: "numeric",
                       month: "short",
                       day: "numeric",
@@ -556,7 +483,7 @@ const PaymentHistory: React.FC = () => {
                       Amount
                     </p>
                     <p className="font-semibold text-sm text-white">
-                      ${payment.amount.toLocaleString()}{" "}
+                      {payment.amount.toLocaleString()}{" "}
                       <span className="text-[11px] text-text-secondary font-normal uppercase">
                         {payment.token}
                       </span>
@@ -567,16 +494,20 @@ const PaymentHistory: React.FC = () => {
                 {/* Bottom row: tx hash */}
                 <div className="flex items-center justify-between pt-2.5 border-t border-[rgba(98,255,255,0.1)]">
                   <span className="text-[11px] text-text-secondary">Tx Hash</span>
-                  <a
-                    href={getStellarExplorerUrl(payment.txHash)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="font-mono text-xs text-text-secondary inline-flex items-center gap-1 hover:text-[#62ffff] transition-colors"
-                  >
-                    {truncateHash(payment.txHash)}
-                    <ExternalLink size={11} className="text-[#62ffff]" aria-hidden="true" />
-                  </a>
+                  {payment.stellarTxHash ? (
+                    <a
+                      href={getStellarExplorerUrl(payment.stellarTxHash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="font-mono text-xs text-text-secondary inline-flex items-center gap-1 hover:text-[#62ffff] transition-colors"
+                    >
+                      {truncateHash(payment.stellarTxHash)}
+                      <ExternalLink size={11} className="text-[#62ffff]" aria-hidden="true" />
+                    </a>
+                  ) : (
+                    <span className="font-mono text-xs text-text-secondary">-</span>
+                  )}
                 </div>
               </button>
             ))}
@@ -585,9 +516,7 @@ const PaymentHistory: React.FC = () => {
       {/* Pagination */}
       <div className="flex justify-between items-center px-6 py-4 bg-[rgba(19,186,186,0.05)] border border-[rgba(98,255,255,0.2)] rounded-xl shadow-[inset_0_0_15px_0px_rgba(0,128,128,0.2)] max-md:flex-col max-md:gap-4">
         <div className="text-sm text-text-secondary">
-          Showing {startIndex + 1}–
-          {Math.min(startIndex + itemsPerPage, sortedPayments.length)} of{" "}
-          {sortedPayments.length}
+          Page {currentPage} of {totalPages} &middot; {total} total
         </div>
         <div className="flex gap-2 max-md:w-full max-md:justify-center flex-wrap">
           <button
@@ -625,7 +554,9 @@ const PaymentHistory: React.FC = () => {
       <PaymentDetailModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        payment={selectedPayment}
+        settlement={selectedPayment}
+        detail={selectedDetail}
+        isLoading={isModalLoading}
       />
     </div>
   );

--- a/frontend/src/pages/Settlements/Settlements.tsx
+++ b/frontend/src/pages/Settlements/Settlements.tsx
@@ -4,10 +4,11 @@ import {
   ExternalLink,
   ChevronLeft,
   ChevronRight,
-  Loader2,
   Receipt,
+  AlertTriangle,
 } from "lucide-react";
 import EmptyState from "../../components/common/EmptyState/EmptyState";
+import TableRowSkeleton from "@components/ui/Skeleton/TableRowSkeleton";
 import { Link } from "react-router-dom";
 import {
   settlementsApi,
@@ -54,15 +55,6 @@ const statusDotClasses: Record<SettlementStatus, string> = {
 };
 
 const toStatusLabel = (s: SettlementStatus) => s;
-
-const LoadingState: React.FC = () => (
-  <div className="p-6 md:p-4">
-    <div className="flex items-center gap-3 text-text-secondary">
-      <Loader2 className="animate-spin" size={18} />
-      Loading settlements...
-    </div>
-  </div>
-);
 
 export default function Settlements() {
   const { role } = useAuthContext();
@@ -186,23 +178,21 @@ export default function Settlements() {
     "text-left px-6 py-4 text-[11px] font-semibold text-[#62ffff] uppercase border-b border-[rgba(98,255,255,0.2)]";
   const tdClass = "px-6 py-4 text-sm border-b border-[rgba(98,255,255,0.2)]";
 
-  if (isLoading) return <LoadingState />;
   if (error) {
     return (
       <div className="p-6 md:p-4">
-        <div className="bg-red-500/10 border border-red-500/30 rounded-2xl p-6">
-          <div className="text-red-200 font-semibold mb-2">Error</div>
-          <div className="text-text-secondary text-sm mb-4">{error}</div>
-          <button
-            onClick={() => {
+        <EmptyState
+          icon={<AlertTriangle size={28} />}
+          title="Failed to load settlements"
+          description={error}
+          cta={{
+            label: "Retry",
+            onClick: () => {
               setCurrentPage(1);
               void load();
-            }}
-            className="px-4 py-2 rounded-lg border border-[rgba(98,255,255,0.2)] text-text-primary hover:border-[#62ffff] hover:text-[#62ffff]"
-          >
-            Retry
-          </button>
-        </div>
+            },
+          }}
+        />
       </div>
     );
   }
@@ -298,7 +288,34 @@ export default function Settlements() {
         </div>
       </div>
 
-      {settlements.length === 0 ? (
+      {isLoading ? (
+        <div className={`${tableContainerClass} hidden md:block overflow-x-auto`}>
+          <table className="w-full border-collapse min-w-200">
+            <thead className="bg-[rgba(19,186,186,0.1)]">
+              <tr>
+                <th className={thClass}>Date</th>
+                <th className={thClass}>Shipment ID</th>
+                <th className={thClass}>Amount</th>
+                <th className={thClass}>Status</th>
+                <th className={thClass}>Stellar Tx</th>
+              </tr>
+            </thead>
+            <tbody>
+              <TableRowSkeleton count={limit} />
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+      {isLoading ? (
+        <div className="md:hidden flex flex-col gap-3">
+          {[...Array(4)].map((_, i) => (
+            <div
+              key={i}
+              className="h-28 rounded-2xl bg-[rgba(98,255,255,0.05)] border border-[rgba(98,255,255,0.2)] animate-pulse"
+            />
+          ))}
+        </div>
+      ) : settlements.length === 0 ? (
         <div className="p-6 md:p-4">
           <EmptyState
             icon={<Receipt size={28} />}


### PR DESCRIPTION
…tlements to real API

Closes #593
- Extract token-check logic in useAuth into named checkToken()
- Add visibilitychange listener that re-validates the JWT when the tab regains focus; clears localStorage and sets isAuthenticated:false on an expired token found via focus
- Add useAuth.test.ts covering mount + focus revalidation (valid/expired)

Closes #592
- Expand HelpCenter.tsx with an FAQ accordion, a quick links card grid (Blockchain Ledger, Settlements, Analytics, restart tour), a keyboard shortcuts reference table matching useKeyboardShortcuts/DashboardLayout, and a video placeholder card with a data-src attribute

Closes #591
- Remove hardcoded Payment[] mock data and local pagination math from PaymentHistory.tsx
- Fetch via settlementsApi.getSettlements on mount and on filter/sort/page change; loading state uses shared TableRowSkeleton, error state uses EmptyState with retry
- statusClasses covers all SettlementStatus values (incl. DISPUTED)
- Detail modal loads real data via settlementsApi.getSettlementById and traps focus via useFocusTrap

Closes #590
- Settlements.tsx was already wired to settlementsApi (getSettlements/ getSettlementById) with filters and a real PaymentDetailModal from a prior change; this closes the remaining gap by swapping the full-page loading spinner for TableRowSkeleton (header/filters stay visible while fetching) and using EmptyState with a retry action for errors

## Issue
Closes #

## Description
<!-- Brief summary of what you built or fixed -->

## Testing
<!-- How you verified it works - list what you tested -->
- [ ] Ran `pnpm run lint` (no errors)
- [ ] Ran `pnpm run build` (builds successfully)
- [ ] Ran `pnpm run test` (all tests pass)
- [ ] Tested in browser (describe what you tested)

## Screenshots/Recording
<!-- **REQUIRED for all frontend PRs** - attach screenshots or screen recording -->

## Checklist
- [ ] My PR targets the `dev` branch (not `main`)
- [ ] My branch is up-to-date with `dev`
- [ ] I followed the code standards in CONTRIBUTING.md
- [ ] I added/updated tests if needed
- [ ] All CI checks pass

## Accessibility Review
- [ ] Interactive controls have clear labels and visible focus states
- [ ] Keyboard users can reach and operate new UI without a mouse
- [ ] Loading, error, empty, and success states are announced or understandable
- [ ] Text, icons, and status indicators do not rely on color alone
- [ ] Responsive layouts preserve reading order and touch target usability
