### PR TITLE
feat: create useLocalStorage custom hook and migrate useTheme

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -21,3 +21,4 @@ export { default as useWidgetRefresh } from './useWidgetRefresh';
 export type { UseWidgetRefreshOptions, UseWidgetRefreshReturn, RefreshStatus } from './useWidgetRefresh';
 export { useSavedViews } from './useSavedViews';
 export type { UseSavedViewsReturn } from './useSavedViews';
+export { useLocalStorage } from './useLocalStorage';

--- a/frontend/src/hooks/useLocalStorage.test.ts
+++ b/frontend/src/hooks/useLocalStorage.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLocalStorage } from './useLocalStorage';
+
+// setup.ts replaces window.localStorage with a fresh in-memory store per test
+// file, but we still clear it between individual tests for isolation.
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('useLocalStorage', () => {
+  // -------------------------------------------------------------------------
+  // Initial value
+  // -------------------------------------------------------------------------
+  describe('initial value', () => {
+    it('returns initialValue when the key is absent', () => {
+      const { result } = renderHook(() => useLocalStorage('test-key', 42));
+      const [storedValue] = result.current;
+      expect(storedValue).toBe(42);
+    });
+
+    it('returns the value already in storage instead of initialValue', () => {
+      window.localStorage.setItem('test-key', JSON.stringify('hello'));
+      const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+      const [storedValue] = result.current;
+      expect(storedValue).toBe('hello');
+    });
+
+    it('works with object types stored in localStorage', () => {
+      const persisted = { name: 'Alice', age: 30 };
+      window.localStorage.setItem('obj-key', JSON.stringify(persisted));
+      const { result } = renderHook(() =>
+        useLocalStorage('obj-key', { name: '', age: 0 }),
+      );
+      expect(result.current[0]).toEqual(persisted);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Writing a new value
+  // -------------------------------------------------------------------------
+  describe('setValue', () => {
+    it('updates state with a direct value', () => {
+      const { result } = renderHook(() => useLocalStorage('count', 0));
+
+      act(() => {
+        result.current[1](99);
+      });
+
+      expect(result.current[0]).toBe(99);
+      expect(JSON.parse(window.localStorage.getItem('count') ?? 'null')).toBe(99);
+    });
+
+    it('updates state with an updater function', () => {
+      const { result } = renderHook(() => useLocalStorage('count', 10));
+
+      act(() => {
+        result.current[1]((prev) => prev + 5);
+      });
+
+      expect(result.current[0]).toBe(15);
+      expect(JSON.parse(window.localStorage.getItem('count') ?? 'null')).toBe(15);
+    });
+
+    it('serialises objects to JSON in localStorage', () => {
+      const { result } = renderHook(() =>
+        useLocalStorage<{ flag: boolean }>('obj', { flag: false }),
+      );
+
+      act(() => {
+        result.current[1]({ flag: true });
+      });
+
+      expect(result.current[0]).toEqual({ flag: true });
+      expect(JSON.parse(window.localStorage.getItem('obj') ?? '{}')).toEqual({ flag: true });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Removing a value
+  // -------------------------------------------------------------------------
+  describe('removeValue', () => {
+    it('clears the key from localStorage', () => {
+      window.localStorage.setItem('theme', JSON.stringify('dark'));
+      const { result } = renderHook(() => useLocalStorage('theme', 'light'));
+
+      act(() => {
+        result.current[2](); // removeValue
+      });
+
+      expect(window.localStorage.getItem('theme')).toBeNull();
+    });
+
+    it('resets state to initialValue (not null)', () => {
+      const { result } = renderHook(() => useLocalStorage('theme', 'light'));
+
+      // First write something
+      act(() => {
+        result.current[1]('dark');
+      });
+      expect(result.current[0]).toBe('dark');
+
+      // Then remove it
+      act(() => {
+        result.current[2]();
+      });
+
+      expect(result.current[0]).toBe('light');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Corrupted / invalid JSON
+  // -------------------------------------------------------------------------
+  describe('corrupted JSON recovery', () => {
+    it('falls back to initialValue when stored data is not valid JSON', () => {
+      window.localStorage.setItem('corrupt', 'not-valid-json{{{');
+      const { result } = renderHook(() => useLocalStorage('corrupt', 'fallback'));
+      expect(result.current[0]).toBe('fallback');
+    });
+
+    it('does not throw when stored data is corrupted', () => {
+      window.localStorage.setItem('corrupt2', '!!invalid!!');
+      expect(() =>
+        renderHook(() => useLocalStorage('corrupt2', 0)),
+      ).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -1,0 +1,68 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * A type-safe, generic hook that syncs a value to `window.localStorage`.
+ *
+ * @param key          - The localStorage key to read/write.
+ * @param initialValue - Fallback value when the key is absent or the stored
+ *                       JSON cannot be parsed.
+ * @returns A tuple of `[storedValue, setValue, removeValue]`.
+ */
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): readonly [T, (value: T | ((prev: T) => T)) => void, () => void] {
+  // Lazy initialiser — read from storage once on mount.
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    // SSR guard: window may be absent in server-side environments.
+    if (typeof window === 'undefined') return initialValue;
+
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw === null) return initialValue;
+      return JSON.parse(raw) as T;
+    } catch {
+      // Corrupted / invalid JSON — fall back silently.
+      return initialValue;
+    }
+  });
+
+  /**
+   * Persist a new value (or apply an updater function) to localStorage and
+   * update React state so consumers re-render.
+   */
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      setStoredValue((prev) => {
+        const next = value instanceof Function ? value(prev) : value;
+
+        if (typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(key, JSON.stringify(next));
+          } catch {
+            // Quota exceeded or storage unavailable — update state anyway.
+          }
+        }
+
+        return next;
+      });
+    },
+    [key],
+  );
+
+  /**
+   * Remove the key from localStorage and reset state to `initialValue`.
+   */
+  const removeValue = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // Storage unavailable — proceed to reset state.
+      }
+    }
+    setStoredValue(initialValue);
+  }, [key, initialValue]);
+
+  return [storedValue, setValue, removeValue] as const;
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, createElement, type ReactNode } from 'react';
+import { useLocalStorage } from './useLocalStorage';
 
 type Theme = 'dark' | 'light';
 
@@ -7,13 +8,6 @@ const STORAGE_KEY = 'navin-theme';
 function getSystemPreference(): Theme {
   if (typeof window === 'undefined') return 'dark';
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-}
-
-function getInitialTheme(): Theme {
-  if (typeof window === 'undefined') return 'dark';
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored === 'dark' || stored === 'light') return stored;
-  return getSystemPreference();
 }
 
 function applyTheme(theme: Theme) {
@@ -33,16 +27,28 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  // Persist the chosen theme via useLocalStorage.
+  // We derive the initial value from system preference when nothing is stored
+  // yet — this mirrors the previous `getInitialTheme` logic.
+  const [storedTheme, setStoredTheme] = useLocalStorage<Theme | null>(
+    STORAGE_KEY,
+    null,
+  );
 
+  const [theme, setTheme] = useState<Theme>(
+    storedTheme ?? getSystemPreference(),
+  );
+
+  // Apply the theme class to <html> whenever theme changes.
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
 
+  // Respond to system dark-mode changes when no explicit preference is stored.
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handleSystemChange = (e: MediaQueryListEvent) => {
-      if (!localStorage.getItem(STORAGE_KEY)) {
+      if (storedTheme === null) {
         setTheme(e.matches ? 'dark' : 'light');
       }
     };
@@ -60,15 +66,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       mq.removeEventListener('change', handleSystemChange);
       window.removeEventListener('storage', handleStorage);
     };
-  }, []);
+  }, [storedTheme]);
 
   const toggleTheme = useCallback(() => {
     setTheme((prev) => {
       const next: Theme = prev === 'dark' ? 'light' : 'dark';
-      localStorage.setItem(STORAGE_KEY, next);
+      setStoredTheme(next);
       return next;
     });
-  }, []);
+  }, [setStoredTheme]);
 
   return createElement(ThemeContext.Provider, { value: { theme, toggleTheme } }, children);
 }


### PR DESCRIPTION
## Summary

Closes #616

Implements a type-safe, generic `useLocalStorage<T>` custom hook to replace direct `localStorage` access, and migrates `useTheme.ts` to use it.

## Changes

### `frontend/src/hooks/useLocalStorage.ts` (new)
- Generic `useLocalStorage<T>(key, initialValue)` returning `[storedValue, setValue, removeValue] as const`
- `setValue` accepts a direct value **or** an updater function `(prev: T) => T`
- `removeValue` clears the key from `localStorage` and resets state to `initialValue` (never `null`)
- All reads/writes in `try/catch` - corrupted/invalid JSON falls back to `initialValue` silently
- SSR guard: `typeof window === 'undefined'` check before any `window.localStorage` access

### `frontend/src/hooks/useLocalStorage.test.ts` (new)
10 tests covering:
- Returns `initialValue` when key is absent
- Reads an existing value from storage on mount
- `setValue` with a direct value and with an updater function
- Object serialisation round-trip
- `removeValue` clears storage and resets state to `initialValue` (not `null`)
- Graceful recovery from corrupted JSON (no throw, returns `initialValue`)

### `frontend/src/hooks/useTheme.ts` (modified)
Replaced direct `localStorage.getItem` / `localStorage.setItem` calls with `useLocalStorage`. External API (`useTheme`, `ThemeProvider`, `toggleTheme`) is unchanged.

### `frontend/src/hooks/index.ts` (modified)
Added: `export { useLocalStorage } from './useLocalStorage'`

## Testing

`
pnpm exec vitest run src/hooks/useLocalStorage.test.ts
10/10 tests passed
`

All four touched files pass ESLint with zero errors or warnings.

## Screenshots

Hooks-only change - no UI output.